### PR TITLE
ignore example table.docx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ dist
 node_modules
 # pkg
 *.docx#
-test.docx
+*.docx
 output/*.docx
 vrt/screenshot/actual
 vrt/screenshot/diff


### PR DESCRIPTION
## What does this change?

Ignores any `.docx` file in the root of the repository. I noticed the `table.docx` was included after running `cargo run --example table`.

## References

- NA

## Screenshots

NA

## What can I check for bug fixes?
From a clone of the repository:
- Run `cargo run --example table`
- Verify working directory is clean
