### PR TITLE
fix: document error

### DIFF
--- a/docx-core/examples/reader.rs
+++ b/docx-core/examples/reader.rs
@@ -4,7 +4,7 @@ use std::fs::File;
 use std::io::{Read, Write};
 
 pub fn main() {
-    let mut file = File::open("./style_test.docx").unwrap();
+    let mut file = File::open("./issue2405.docx").unwrap();
     let mut buf = vec![];
     file.read_to_end(&mut buf).unwrap();
     dbg!(read_docx(&buf).unwrap().json());

--- a/docx-core/src/reader/attributes/indent.rs
+++ b/docx-core/src/reader/attributes/indent.rs
@@ -21,21 +21,23 @@ pub fn read_indent(attrs: &[OwnedAttribute]) -> ReadIndentResult {
     let mut start_chars: Option<i32> = None;
     let mut end: Option<i32> = None;
     let mut special: Option<SpecialIndentType> = None;
-
     for a in attrs {
         let local_name = &a.name.local_name;
         if local_name == "left" || local_name == "start" {
-            start = Some(f64::from_str(&a.value)? as i32);
+            let v = super::value_to_dax(&a.value)?;
+            start = Some(v);
         } else if local_name == "leftChars" || local_name == "startChars" {
             start_chars = Some(i32::from_str(&a.value)?);
         } else if local_name == "end" || local_name == "right" {
-            end = Some(f64::from_str(&a.value)? as i32);
+            let v = super::value_to_dax(&a.value)?;
+            end = Some(v);
         } else if local_name == "hanging" {
-            special = Some(SpecialIndentType::Hanging(f64::from_str(&a.value)? as i32))
+            let v = super::value_to_dax(&a.value)?;
+            special = Some(SpecialIndentType::Hanging(v))
         } else if local_name == "firstLine" {
-            special = Some(SpecialIndentType::FirstLine(f64::from_str(&a.value)? as i32))
+            let v = super::value_to_dax(&a.value)?;
+            special = Some(SpecialIndentType::FirstLine(v))
         }
     }
-
     Ok((start, end, special, start_chars))
 }

--- a/docx-core/src/reader/attributes/val.rs
+++ b/docx-core/src/reader/attributes/val.rs
@@ -1,4 +1,8 @@
+use std::str::FromStr;
+
 use xml::attribute::OwnedAttribute;
+
+use super::super::errors::*;
 
 pub fn read_val(attrs: &[OwnedAttribute]) -> Option<String> {
     for a in attrs {
@@ -8,4 +12,13 @@ pub fn read_val(attrs: &[OwnedAttribute]) -> Option<String> {
         }
     }
     None
+}
+
+pub fn value_to_dax(v: &str) -> Result<i32, ReaderError> {
+    if v.ends_with("pt") {
+        let v = f64::from_str(&v.replace("pt", ""))? as i32;
+        Ok(v * 20)
+    } else {
+        Ok(f64::from_str(v)? as i32)
+    }
 }

--- a/docx-core/src/reader/paragraph.rs
+++ b/docx-core/src/reader/paragraph.rs
@@ -13,7 +13,7 @@ fn read_lineheight(attributes: &[OwnedAttribute]) -> Option<u32> {
     for a in attributes {
         let local_name = &a.name.local_name;
         if let "line" = local_name.as_str() {
-            return f32::from_str(&a.value).ok().map(|l| l as u32);
+            return value_to_dax(&a.value).ok().map(|l| l as u32);
         }
     }
     None

--- a/docx-core/src/reader/run_property.rs
+++ b/docx-core/src/reader/run_property.rs
@@ -31,7 +31,8 @@ impl ElementReader for RunProperty {
                         XMLElement::Size => rp = rp.size(usize::from_str(&attributes[0].value)?),
                         XMLElement::Spacing => {
                             if let Some(v) = read_val(&attributes) {
-                                rp = rp.spacing(f32::from_str(&v)? as i32)
+                                let v = value_to_dax(&v)?;
+                                rp = rp.spacing(v)
                             }
                         }
                         XMLElement::Underline => rp = rp.underline(&attributes[0].value.clone()),

--- a/docx-core/src/reader/section_property.rs
+++ b/docx-core/src/reader/section_property.rs
@@ -12,10 +12,10 @@ fn read_page_size(attributes: &[OwnedAttribute]) -> Result<PageSize, ReaderError
         let local_name = &a.name.local_name;
         match local_name.as_str() {
             "w" => {
-                size = size.width(f32::from_str(&a.value)? as u32);
+                size = size.width(value_to_dax(&a.value)? as u32);
             }
             "h" => {
-                size = size.height(f32::from_str(&a.value)? as u32);
+                size = size.height(value_to_dax(&a.value)? as u32);
             }
             _ => {}
         }
@@ -31,25 +31,25 @@ fn read_page_margin(
         let local_name = &a.name.local_name;
         match local_name.as_str() {
             "top" => {
-                margin = margin.top(f32::from_str(&a.value)? as u32);
+                margin = margin.top(value_to_dax(&a.value)? as u32);
             }
             "right" => {
-                margin = margin.right(f32::from_str(&a.value)? as u32);
+                margin = margin.right(value_to_dax(&a.value)? as u32);
             }
             "bottom" => {
-                margin = margin.bottom(f32::from_str(&a.value)? as u32);
+                margin = margin.bottom(value_to_dax(&a.value)? as u32);
             }
             "left" => {
-                margin = margin.left(f32::from_str(&a.value)? as u32);
+                margin = margin.left(value_to_dax(&a.value)? as u32);
             }
             "header" => {
-                margin = margin.header(f32::from_str(&a.value)? as u32);
+                margin = margin.header(value_to_dax(&a.value)? as u32);
             }
             "footer" => {
-                margin = margin.footer(f32::from_str(&a.value)? as u32);
+                margin = margin.footer(value_to_dax(&a.value)? as u32);
             }
             "gutter" => {
-                margin = margin.gutter(f32::from_str(&a.value)? as u32);
+                margin = margin.gutter(value_to_dax(&a.value)? as u32);
             }
             _ => {}
         }

--- a/docx-core/src/reader/table_row.rs
+++ b/docx-core/src/reader/table_row.rs
@@ -40,7 +40,10 @@ impl ElementReader for TableRow {
                         }
                         XMLElement::TableRowHeight => {
                             if let Some(v) = read_val(&attributes) {
-                                row_height = Some(f32::from_str(&v)?);
+                                let h = f32::from_str(&v);
+                                if let Ok(h) = h {
+                                    row_height = Some(h);
+                                }
                             }
                         }
                         _ => {}


### PR DESCRIPTION
## What does this change?

- fallback to default path when document_rel is not found.
- use, `pt` to `dax` convertor this is because some document include `pt` in size.

## References

- If you have links to other resources, please list them here. (e.g. issue url, related pull request url, documents)

## Screenshots

If applicable, add screenshots to help explain your changes.

## What can I check for bug fixes?

Please briefly describe how you can confirm the resolution of the bug.
