### PR TITLE
fix: replace backslash before read_zip

### DIFF
--- a/docx-core/src/reader/read_zip.rs
+++ b/docx-core/src/reader/read_zip.rs
@@ -8,7 +8,7 @@ pub fn read_zip(
 ) -> Result<Vec<u8>, ReaderError> {
     let mut p = name.to_owned();
     // Archives zipped on Windows keep '\' in paths, replace them to avoid zip error.
-    let mut p = str::replace(&p, "\\", "/");
+    let p = str::replace(&p, "\\", "/");
     if p.starts_with('/') {
         p.remove(0);
     }

--- a/docx-core/src/reader/read_zip.rs
+++ b/docx-core/src/reader/read_zip.rs
@@ -6,7 +6,7 @@ pub fn read_zip(
     archive: &mut zip::read::ZipArchive<Cursor<&[u8]>>,
     name: &str,
 ) -> Result<Vec<u8>, ReaderError> {
-    let mut p = name.to_owned();
+    let p = name.to_owned();
     // Archives zipped on Windows keep '\' in paths, replace them to avoid zip error.
     let mut p = str::replace(&p, "\\", "/");
     if p.starts_with('/') {

--- a/docx-core/src/reader/read_zip.rs
+++ b/docx-core/src/reader/read_zip.rs
@@ -7,6 +7,8 @@ pub fn read_zip(
     name: &str,
 ) -> Result<Vec<u8>, ReaderError> {
     let mut p = name.to_owned();
+    // Archives zipped on Windows keep '\' in paths, replace them to avoid zip error.
+    let mut p = str::replace(&p, "\\", "/");
     if p.starts_with('/') {
         p.remove(0);
     }

--- a/docx-core/src/reader/read_zip.rs
+++ b/docx-core/src/reader/read_zip.rs
@@ -8,7 +8,7 @@ pub fn read_zip(
 ) -> Result<Vec<u8>, ReaderError> {
     let mut p = name.to_owned();
     // Archives zipped on Windows keep '\' in paths, replace them to avoid zip error.
-    let p = str::replace(&p, "\\", "/");
+    let mut p = str::replace(&p, "\\", "/");
     if p.starts_with('/') {
         p.remove(0);
     }


### PR DESCRIPTION
Docx files created by Word 2021 contains backslash in path, it causes read_zip function `ZipError(FileNotFound)` when reading an exsist docx file.
By replace backslashes to slashes to fix it.


- [Zipped paths include '\'s instead of changing them to '/'s](https://github.com/zip-rs/zip/issues/253)
- [Test cases failed locally](https://github.com/bokuweb/docx-rs/issues/388)
