### PR TITLE
fix author if it have <> chars

### DIFF
--- a/docx-core/src/reader/comment.rs
+++ b/docx-core/src/reader/comment.rs
@@ -4,6 +4,7 @@ use std::str::FromStr;
 use xml::attribute::OwnedAttribute;
 use xml::reader::{EventReader, XmlEvent};
 
+use crate::escape;
 use super::*;
 
 impl ElementReader for Comment {
@@ -14,7 +15,7 @@ impl ElementReader for Comment {
         let id = usize::from_str(&read(attrs, "id").expect("should comment id exists."))?;
         let mut comment = Comment::new(id);
         if let Some(author) = read(attrs, "author") {
-            comment = comment.author(author);
+            comment = comment.author(escape::escape(author.as_str()));
         };
         if let Some(date) = read(attrs, "date") {
             comment = comment.date(date);


### PR DESCRIPTION
## What does this change?

Sometimes author in comments have in name - "< >" (i cant remember, ms word or libreofiice...), and if i read docx and write this docx, this will be error.
This change escape this chars.

## References
https://github.com/bokuweb/docx-rs/issues/499
