### PR TITLE
Support table style

### DIFF
--- a/docx-core/src/documents/elements/style.rs
+++ b/docx-core/src/documents/elements/style.rs
@@ -153,7 +153,11 @@ impl BuildXML for Style {
             .add_child(&self.name)
             .add_child(&self.run_property)
             .add_child(&self.paragraph_property);
-
+        if self.style_type == StyleType::Table {
+            b = b
+                .add_child(&self.table_cell_property)
+                .add_child(&self.table_property);
+        }
         if let Some(ref based_on) = self.based_on {
             b = b.add_child(based_on)
         }

--- a/docx-core/src/documents/styles.rs
+++ b/docx-core/src/documents/styles.rs
@@ -104,6 +104,22 @@ mod tests {
     }
 
     #[test]
+    fn test_table_style(){
+        let c =
+            Styles::new().add_style(Style::new("Table", StyleType::Table).name("Table Style").table_property(TableProperty::new().set_margins(TableCellMargins::new().margin_left(108, WidthType::Dxa).margin_right(108,WidthType::Dxa))));
+        let b = c.build();
+        assert_eq!(
+            str::from_utf8(&b).unwrap(),
+            r#"<w:styles xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml" xmlns:w15="http://schemas.microsoft.com/office/word/2012/wordml" mc:Ignorable="w14 w15"><w:docDefaults><w:rPrDefault><w:rPr /></w:rPrDefault></w:docDefaults><w:style w:type="paragraph" w:styleId="Normal"><w:name w:val="Normal" /><w:rPr /><w:pPr><w:rPr /></w:pPr><w:qFormat /></w:style><w:style w:type="table" w:styleId="Table"><w:name w:val="Table Style" /><w:rPr /><w:pPr><w:rPr /></w:pPr><w:tcPr /><w:tblPr><w:tblW w:w="0" w:type="dxa" /><w:jc w:val="left" /><w:tblBorders><w:top w:val="single" w:sz="2" w:space="0" w:color="000000" /><w:left w:val="single" w:sz="2" w:space="0" w:color="000000" /><w:bottom w:val="single" w:sz="2" w:space="0" w:color="000000" /><w:right w:val="single" w:sz="2" w:space="0" w:color="000000" /><w:insideH w:val="single" w:sz="2" w:space="0" w:color="000000" /><w:insideV w:val="single" w:sz="2" w:space="0" w:color="000000" /></w:tblBorders><w:tblCellMar>
+  <w:top w:w="0" w:type="dxa" />
+  <w:left w:w="108" w:type="dxa" />
+  <w:bottom w:w="0" w:type="dxa" />
+  <w:right w:w="108" w:type="dxa" />
+</w:tblCellMar></w:tblPr><w:qFormat /></w:style></w:styles>"#
+        );
+    }
+
+    #[test]
     fn test_heading_style() {
         let c = Styles::new().add_style(Style::new("ToC", StyleType::Paragraph).name("heading 3"));
         let mut m = std::collections::HashMap::new();


### PR DESCRIPTION
## What does this change?
- Corresponds to the case where the StyleType is set to "Table" and a TableProperty is added, but no output is generated.
- TableProperty and TableCellProperty do not output when the style type is not "Table".
- The following code is intended to work
```
set style (mut docx:  Docx) -> Docx{
    let mut style  = Style::new(String::from("TableStyle1"), style_type::StyleType::Table);
    style = style.name(String::from("default table style"));
    let cell_margins = TableCellMargins::new()
        .margin_left(108, WidthType::Dxa)
        .margin_right(108, WidthType::Dxa);
    style.table_property(TableProperty::new().set_margins(cell_margins));
    docx = docx.add_style(style);
    docx
}
```