### PR TITLE
Issue393

### DIFF
--- a/docx-core/src/documents/mod.rs
+++ b/docx-core/src/documents/mod.rs
@@ -921,7 +921,9 @@ fn collect_images_from_paragraph(
                 if let RunChild::Drawing(d) = child {
                     if let Some(DrawingData::Pic(pic)) = &mut d.data {
                         let b = std::mem::take(&mut pic.image);
-                        let buf = image_bufs.iter().find(|x| x.1 == b.clone());
+                        let buf = image_bufs
+                            .iter()
+                            .find(|x| x.0 == pic.id.clone() || x.1 == b.clone());
                         if buf.as_ref().is_none() {
                             images.push((
                                 pic.id.clone(),

--- a/docx-core/src/documents/mod.rs
+++ b/docx-core/src/documents/mod.rs
@@ -920,14 +920,17 @@ fn collect_images_from_paragraph(
             for child in &mut run.children {
                 if let RunChild::Drawing(d) = child {
                     if let Some(DrawingData::Pic(pic)) = &mut d.data {
-                        if !images.contains(&(pic.id.clone(), format!("media/{}.png", &pic.id))) {
+                        let b = std::mem::take(&mut pic.image);
+                        let buf = image_bufs.iter().find(|x| x.1 == b.clone());
+                        if buf.as_ref().is_none() {
                             images.push((
                                 pic.id.clone(),
                                 // For now only png supported
                                 format!("media/{}.png", pic.id),
                             ));
-                            let b = std::mem::take(&mut pic.image);
                             image_bufs.push((pic.id.clone(), b));
+                        } else {
+                            pic.id = buf.unwrap().0.clone();
                         }
                     }
                 }

--- a/docx-core/src/documents/mod.rs
+++ b/docx-core/src/documents/mod.rs
@@ -920,13 +920,15 @@ fn collect_images_from_paragraph(
             for child in &mut run.children {
                 if let RunChild::Drawing(d) = child {
                     if let Some(DrawingData::Pic(pic)) = &mut d.data {
-                        images.push((
-                            pic.id.clone(),
-                            // For now only png supported
-                            format!("media/{}.png", pic.id),
-                        ));
-                        let b = std::mem::take(&mut pic.image);
-                        image_bufs.push((pic.id.clone(), b));
+                        if !images.contains(&(pic.id.clone(), format!("media/{}.png", &pic.id))) {
+                            images.push((
+                                pic.id.clone(),
+                                // For now only png supported
+                                format!("media/{}.png", pic.id),
+                            ));
+                            let b = std::mem::take(&mut pic.image);
+                            image_bufs.push((pic.id.clone(), b));
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## What does this change?
- Response to issue393
- Modified to consolidate output image files when the same image is used multiple times.

## Sample Code (base to issue393)
```
pub fn main() -> Result<(), DocxError> {
    let path = std::path::Path::new("./test.docx");
    let file = File::create(&path).unwrap();
    let mut img = File::open("./image1.png").unwrap();
    let mut buf = Vec::new();
    let _ = img.read_to_end(&mut buf).unwrap();

    let doc = create_docx("testcode", "barcode", &buf);
    doc.build().pack(file)?;
    Ok(())
}

fn create_docx(code: &str, barcode: &str, barcodes_image: &Vec<u8>) -> Docx {
    Docx::new()
        .page_margin(
            PageMargin::new()
                .header(0)
                .bottom(0)
                .footer(0)
                .left(0)
                .right(0)
                .top(0)
                .gutter(0),
        )
        .add_table(create_table(code, barcode, barcodes_image))
}

fn create_table(code: &str, barcode: &str, barcodes_image: &Vec<u8>) -> Table {
    let rows = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
        .iter()
        .map(|_| create_row(code, barcode, barcodes_image))
        .collect();

    Table::new(rows)
        .layout(TableLayoutType::Fixed)
        .indent(0)
        .width(11880, WidthType::Dxa)
}

fn create_row(code: &str, barcode: &str, barcodes_image: &Vec<u8>) -> TableRow {
    let cells = [0, 1, 2, 3]
        .iter()
        .map(|_| create_cell(code, barcode, barcodes_image.clone()))
        .collect();

    TableRow::new(cells)
        .row_height(1678f32)
        .height_rule(docx_rs::HeightRule::Exact)
}

fn create_cell(code: &str, barcode: &str, barcodes_image: Vec<u8>) -> TableCell {
    TableCell::new()
        .add_paragraph(
            Paragraph::default()
                .add_run(
                    Run::new()
                        .add_image(
                            Pic::new(&barcodes_image)
                                .floating()
                                .offset_x(20)
                                .offset_y(10)
                                .size(155 * 9525, 45 * 9525),
                        )
                        .add_break(BreakType::TextWrapping)
                        .add_break(BreakType::TextWrapping)
                        .add_text(barcode)
                        .add_break(BreakType::TextWrapping)
                        .add_text(code)
                        .fonts(
                            RunFonts::new()
                                .east_asia("Calibri")
                                .ascii("Calibri")
                                .hi_ansi("Calibri"),
                        )
                        .size(22)
                        .character_spacing(0),
                )
                .align(AlignmentType::Center),
        )
        .clear_all_border()
        .vertical_align(VAlignType::Center)
}
```

##  More better sample code ( Clone and use Pic )
```
pub fn main() -> Result<(), DocxError> {
    let path = std::path::Path::new("./test.docx");
    let file = File::create(&path).unwrap();
    let mut img = File::open("./image1.png").unwrap();
    let mut buf = Vec::new();
    let _ = img.read_to_end(&mut buf).unwrap();

    let doc = create_docx("testcode", "barcode", &buf);
    doc.build().pack(file)?;
    Ok(())
}

fn create_docx(code: &str, barcode: &str, barcodes_image: &Vec<u8>) -> Docx {
    let pic = Pic::new(&barcodes_image);
    Docx::new()
        .page_margin(
            PageMargin::new()
                .header(0)
                .bottom(0)
                .footer(0)
                .left(0)
                .right(0)
                .top(0)
                .gutter(0),
        )
        .add_table(create_table(code, barcode, pic))
}

fn create_table(code: &str, barcode: &str, pic: Pic) -> Table {
    let rows = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
        .iter()
        .map(|_| create_row(code, barcode, pic.clone()))
        .collect();

    Table::new(rows)
        .layout(TableLayoutType::Fixed)
        .indent(0)
        .width(11880, WidthType::Dxa)
}

fn create_row(code: &str, barcode: &str, pic: Pic) -> TableRow {
    let cells = [0, 1, 2, 3]
        .iter()
        .map(|_| create_cell(code, barcode, pic.clone()))
        .collect();

    TableRow::new(cells)
        .row_height(1678f32)
        .height_rule(docx_rs::HeightRule::Exact)
}

fn create_cell(code: &str, barcode: &str, pic: Pic) -> TableCell {
    TableCell::new()
        .add_paragraph(
            Paragraph::default()
                .add_run(
                    Run::new()
                        .add_image(
                            pic.floating()
                                .offset_x(20)
                                .offset_y(10)
                                .size(155 * 9525, 45 * 9525),
                        )
                        .add_break(BreakType::TextWrapping)
                        .add_break(BreakType::TextWrapping)
                        .add_text(barcode)
                        .add_break(BreakType::TextWrapping)
                        .add_text(code)
                        .fonts(
                            RunFonts::new()
                                .east_asia("Calibri")
                                .ascii("Calibri")
                                .hi_ansi("Calibri"),
                        )
                        .size(22)
                        .character_spacing(0),
                )
                .align(AlignmentType::Center),
        )
        .clear_all_border()
        .vertical_align(VAlignType::Center)
}
```