### PR TITLE
Support image align

### DIFF
--- a/docx-core/src/documents/elements/drawing.rs
+++ b/docx-core/src/documents/elements/drawing.rs
@@ -271,7 +271,7 @@ mod tests {
   <wp:anchor distT="0" distB="0" distL="0" distR="0" simplePos="0" allowOverlap="0" behindDoc="0" locked="0" layoutInCell="0" relativeHeight="190500">
     <wp:simplePos x="0" y="0" />
     <wp:positionH relativeFrom="column">
-      <wp:align alignText="right" />
+      <wp:align>right</wp:align>
     </wp:positionH>
     <wp:positionV relativeFrom="paragraph">
       <wp:posOffset>0</wp:posOffset>

--- a/docx-core/src/documents/elements/drawing.rs
+++ b/docx-core/src/documents/elements/drawing.rs
@@ -252,4 +252,65 @@ mod tests {
 </w:drawing>"#
         );
     }
+
+    #[test]
+    fn test_drawing_build_with_pic_align_right() {
+        use std::io::Read;
+
+        let mut img = std::fs::File::open("../images/cat_min.jpg").unwrap();
+        let mut buf = Vec::new();
+        let _ = img.read_to_end(&mut buf).unwrap();
+        let mut pic = Pic::new(&buf).floating();
+        pic = pic.relative_from_h(RelativeFromHType::Column);
+        pic = pic.relative_from_v(RelativeFromVType::Paragraph);
+        pic = pic.position_h(DrawingPosition::Align(PicAlign::Right));
+        let d = Box::new(Drawing::new().pic(pic)).build();
+        assert_eq!(
+            str::from_utf8(&d).unwrap(),
+            r#"<w:drawing>
+  <wp:anchor distT="0" distB="0" distL="0" distR="0" simplePos="0" allowOverlap="0" behindDoc="0" locked="0" layoutInCell="0" relativeHeight="190500">
+    <wp:simplePos x="0" y="0" />
+    <wp:positionH relativeFrom="column">
+      <wp:align alignText="right" />
+    </wp:positionH>
+    <wp:positionV relativeFrom="paragraph">
+      <wp:posOffset>0</wp:posOffset>
+    </wp:positionV>
+    <wp:extent cx="3048000" cy="2286000" />
+    <wp:effectExtent b="0" l="0" r="0" t="0" />
+    <wp:wrapSquare wrapText="bothSides" />
+    <wp:docPr id="1" name="Figure" />
+    <wp:cNvGraphicFramePr>
+      <a:graphicFrameLocks xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" noChangeAspect="1" />
+    </wp:cNvGraphicFramePr>
+    <a:graphic xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+      <a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/picture"><pic:pic xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture">
+  <pic:nvPicPr>
+    <pic:cNvPr id="0" name="" />
+    <pic:cNvPicPr>
+      <a:picLocks noChangeAspect="1" noChangeArrowheads="1" />
+    </pic:cNvPicPr>
+  </pic:nvPicPr>
+  <pic:blipFill>
+    <a:blip r:embed="rIdImage123" />
+    <a:srcRect />
+    <a:stretch>
+      <a:fillRect />
+    </a:stretch>
+  </pic:blipFill>
+  <pic:spPr bwMode="auto">
+    <a:xfrm rot="0">
+      <a:off x="0" y="0" />
+      <a:ext cx="3048000" cy="2286000" />
+    </a:xfrm>
+    <a:prstGeom prst="rect">
+      <a:avLst />
+    </a:prstGeom>
+  </pic:spPr>
+</pic:pic></a:graphicData>
+    </a:graphic>
+  </wp:anchor>
+</w:drawing>"#
+        );
+    }
 }

--- a/docx-core/src/documents/elements/pic.rs
+++ b/docx-core/src/documents/elements/pic.rs
@@ -126,6 +126,11 @@ impl Pic {
         self
     }
 
+    pub fn overlapping(mut self) -> Pic {
+        self.allow_overlap = true;
+        self
+    }
+
     pub fn offset_x(mut self, x: i32) -> Pic {
         self.position_h = DrawingPosition::Offset(x);
         self

--- a/docx-core/src/types/drawing_position.rs
+++ b/docx-core/src/types/drawing_position.rs
@@ -1,4 +1,5 @@
 use serde::Serialize;
+use std::fmt::{self};
 
 use wasm_bindgen::prelude::*;
 
@@ -20,6 +21,17 @@ pub enum PicAlign {
     Right,
     Bottom,
     Top,
+}
+
+impl fmt::Display for PicAlign {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            PicAlign::Left => write!(f, "left"),
+            PicAlign::Right => write!(f, "right"),
+            PicAlign::Bottom => write!(f, "bottom"),
+            PicAlign::Top => write!(f, "top"),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, ts_rs::TS)]

--- a/docx-core/src/types/drawing_position.rs
+++ b/docx-core/src/types/drawing_position.rs
@@ -19,6 +19,7 @@ pub enum DrawingPositionType {
 pub enum PicAlign {
     Left,
     Right,
+    Center,
     Bottom,
     Top,
 }
@@ -28,6 +29,7 @@ impl fmt::Display for PicAlign {
         match *self {
             PicAlign::Left => write!(f, "left"),
             PicAlign::Right => write!(f, "right"),
+            PicAlign::Center => write!(f, "center"),
             PicAlign::Bottom => write!(f, "bottom"),
             PicAlign::Top => write!(f, "top"),
         }

--- a/docx-core/src/types/drawing_position.rs
+++ b/docx-core/src/types/drawing_position.rs
@@ -1,5 +1,5 @@
 use serde::Serialize;
-use std::fmt::{self};
+use std::fmt;
 
 use wasm_bindgen::prelude::*;
 

--- a/docx-core/src/xml_builder/drawing.rs
+++ b/docx-core/src/xml_builder/drawing.rs
@@ -43,7 +43,7 @@ impl XMLBuilder {
     open!(open_position_h, "wp:positionH", "relativeFrom");
     open!(open_position_v, "wp:positionV", "relativeFrom");
     closed_with_child!(pos_offset, "wp:posOffset");
-    closed!(align, "wp:align", "alignText");
+    closed_with_child!(align, "wp:align");
     closed!(wrap_none, "wp:wrapNone");
     closed!(wrap_square, "wp:wrapSquare", "wrapText");
 }

--- a/docx-core/src/xml_builder/drawing.rs
+++ b/docx-core/src/xml_builder/drawing.rs
@@ -43,5 +43,7 @@ impl XMLBuilder {
     open!(open_position_h, "wp:positionH", "relativeFrom");
     open!(open_position_v, "wp:positionV", "relativeFrom");
     closed_with_child!(pos_offset, "wp:posOffset");
+    closed!(align, "wp:align", "alignText");
     closed!(wrap_none, "wp:wrapNone");
+    closed!(wrap_square, "wp:wrapSquare", "wrapText");
 }

--- a/docx-wasm/js/json/bindings/PicAlign.ts
+++ b/docx-wasm/js/json/bindings/PicAlign.ts
@@ -1,2 +1,2 @@
 
-export type PicAlign = "left" | "right" | "bottom" | "top";
+export type PicAlign = "left" | "right" | "center" | "bottom" | "top";


### PR DESCRIPTION
## What does this change?

- Support for Pic.position_h when set by DrawingPosition::Align

ex) align right
```
pub fn set_draws(docx: Docx) -> Docx{
    let mut img = std::fs::File::open("./test.jpg").unwrap();
    let mut buf = Vec::new();
    let _ = img.read_to_end(&mut buf).unwrap();
    let mut image = Pic::new(&buf);
    image = image.floating();
    image = image.relative_from_h(RelativeFromHType::Column);
    image = image.relative_from_v(RelativeFromVType::Paragraph);
    image = image.position_h(DrawingPosition::Align(PicAlign::Right));
    docx = docx.add_paragraph(Paragraph::new().add_run(Run::new().add_image()))
    docx
}
```

## What does this change?

Support for Pic.position_h when set by DrawingPosition::Align

ex) align right and text overlap
```
pub fn set_draws(docx: Docx) -> Docx{
    let mut img = std::fs::File::open("./test.jpg").unwrap();
    let mut buf = Vec::new();
    let _ = img.read_to_end(&mut buf).unwrap();
    let mut image = Pic::new(&buf);
    image = image.floating();
    image = image.overlapping();
    image = image.relative_from_h(RelativeFromHType::Column);
    image = image.relative_from_v(RelativeFromVType::Paragraph);
    image = image.position_h(DrawingPosition::Align(PicAlign::Right));
    docx = docx.add_paragraph(Paragraph::new().add_run(Run::new().add_image()))
    docx
}
```
