### PR TITLE
create add_paragraphs method for document and docx structs

### DIFF
--- a/docx-core/src/documents/document.rs
+++ b/docx-core/src/documents/document.rs
@@ -106,6 +106,16 @@ impl Document {
         self
     }
 
+    pub fn add_paragraphs(mut self, paragraphs: Vec<Paragraph>) -> Self {
+        for p in paragraphs.into_iter() {
+            if p.has_numbering {
+                self.has_numbering = true
+            }
+            self.children.push(DocumentChild::Paragraph(Box::new(p)));
+        }
+        self
+    }
+
     pub fn add_table(mut self, t: Table) -> Self {
         if t.has_numbering {
             self.has_numbering = true

--- a/docx-core/src/documents/elements/paragraph.rs
+++ b/docx-core/src/documents/elements/paragraph.rs
@@ -138,6 +138,13 @@ impl Paragraph {
         self
     }
 
+    pub fn add_runs(mut self, runs: Vec<Run>) -> Paragraph {
+        for run in runs.into_iter() {
+            self.children.push(ParagraphChild::Run(Box::new(run)));
+        }
+        self
+    }
+
     pub(crate) fn unshift_run(mut self, run: Run) -> Paragraph {
         self.children.insert(0, ParagraphChild::Run(Box::new(run)));
         self

--- a/docx-core/src/documents/mod.rs
+++ b/docx-core/src/documents/mod.rs
@@ -277,6 +277,16 @@ impl Docx {
         self
     }
 
+    pub fn add_paragraphs(mut self, paragraphs: Vec<Paragraph>) -> Self {
+        for p in paragraphs.into_iter() {
+            if p.has_numbering {
+                self.document_rels.has_numberings = true
+            }
+            self.document = self.document.add_paragraph(p)
+        }
+        self
+    }
+
     pub fn add_structured_data_tag(mut self, t: StructuredDataTag) -> Docx {
         if t.has_numbering {
             // If this document has numbering, set numberings.xml to document_rels.


### PR DESCRIPTION
## What does this change?

This change allows developers(like me) to add a vector of paragraphs directly in a document instead of calling add_paragraph multiple times for adding a batch of paragraphs.

## References

None, but when I was using this library I had trouble adding multiple paragraphs at once in document because I'm using to process a json file into a docx file.

## Screenshots

If applicable, add screenshots to help explain your changes.

## What can I check for bug fixes?

I used it in my application and it worked without any compile time errors.

PS: I also plan on doing the same treatment for the runs struct.
