### PR TITLE
Changing orientation will now flip the size

### DIFF
--- a/docx-core/src/documents/elements/page_size.rs
+++ b/docx-core/src/documents/elements/page_size.rs
@@ -48,6 +48,12 @@ impl PageSize {
     }
 
     pub fn orient(mut self, o: PageOrientationType) -> PageSize {
+        if let Some(orient) = self.orient {
+            if orient != o {
+                self.w, self.h = self.h, self.w;
+            }
+        }
+        
         self.orient = Some(o);
         self
     }


### PR DESCRIPTION

## What does this change?

When changing the orientation of the document, it will now flip the document size.

## References

- https://github.com/bokuweb/docx-rs/issues/603

## Screenshots

If applicable, add screenshots to help explain your changes.

## What can I check for bug fixes?

Not so much a bug, more of a feature change.

You'll find that we no longer have to provide a page size to match the orientation of the document
