### PR TITLE
Wasm feature gate

### DIFF
--- a/docx-core/Cargo.toml
+++ b/docx-core/Cargo.toml
@@ -17,18 +17,21 @@ keywords = [
 name = "docx_rs"
 path = "src/lib.rs"
 
+[features]
+wasm = ["wasm-bindgen", "ts-rs", "serde_json"]
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 xml-rs = "0.8.4"
-wasm-bindgen = "0.2.78"
 thiserror = "1.0"
 zip = { version = "0.6.3", default-features = false, features = ["deflate"] }
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
 base64 = "0.13.1"
 image = { version = "0.24.4", default-features = false, features=["gif", "jpeg", "png", "bmp", "tiff"] }
-ts-rs = "6.1"
+wasm-bindgen = { version = "0.2.78", optional = true }
+ts-rs = { version = "6.1", optional = true }
+serde_json = {version = "1.0", optional = true }
 
 [dev-dependencies]
 pretty_assertions = "1.3.0"

--- a/docx-core/Cargo.toml
+++ b/docx-core/Cargo.toml
@@ -18,7 +18,7 @@ name = "docx_rs"
 path = "src/lib.rs"
 
 [features]
-wasm = ["wasm-bindgen", "ts-rs", "serde_json"]
+wasm = ["wasm-bindgen", "ts-rs"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -27,11 +27,11 @@ xml-rs = "0.8.4"
 thiserror = "1.0"
 zip = { version = "0.6.3", default-features = false, features = ["deflate"] }
 serde = { version = "1.0", features = ["derive"] }
+serde_json = {version = "1.0" }
 base64 = "0.13.1"
 image = { version = "0.24.4", default-features = false, features=["gif", "jpeg", "png", "bmp", "tiff"] }
 wasm-bindgen = { version = "0.2.78", optional = true }
 ts-rs = { version = "6.1", optional = true }
-serde_json = {version = "1.0", optional = true }
 
 [dev-dependencies]
 pretty_assertions = "1.3.0"

--- a/docx-core/src/documents/elements/fld_char.rs
+++ b/docx-core/src/documents/elements/fld_char.rs
@@ -4,7 +4,8 @@ use crate::documents::*;
 use crate::types::*;
 use crate::xml_builder::*;
 
-#[derive(Serialize, Debug, Clone, PartialEq, ts_rs::TS)]
+#[derive(Serialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "wasm", derive(ts_rs::TS))]
 #[ts(export)]
 #[serde(rename_all = "camelCase")]
 pub struct FieldChar {

--- a/docx-core/src/documents/elements/fld_char.rs
+++ b/docx-core/src/documents/elements/fld_char.rs
@@ -6,7 +6,7 @@ use crate::xml_builder::*;
 
 #[derive(Serialize, Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "wasm", derive(ts_rs::TS))]
-#[ts(export)]
+#[cfg_attr(feature = "wasm", ts(export))]
 #[serde(rename_all = "camelCase")]
 pub struct FieldChar {
     pub field_char_type: FieldCharType,

--- a/docx-core/src/documents/elements/font_scheme.rs
+++ b/docx-core/src/documents/elements/font_scheme.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[cfg_attr(feature = "wasm", derive(ts_rs::TS))]
-#[ts(export)]
+#[cfg_attr(feature = "wasm", ts(export))]
 #[serde(rename_all = "camelCase")]
 pub struct FontSchemeFont {
     pub script: String,
@@ -11,7 +11,7 @@ pub struct FontSchemeFont {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Default)]
 #[cfg_attr(feature = "wasm", derive(ts_rs::TS))]
-#[ts(export)]
+#[cfg_attr(feature = "wasm", ts(export))]
 #[serde(rename_all = "camelCase")]
 pub struct FontGroup {
     pub latin: String,
@@ -22,7 +22,7 @@ pub struct FontGroup {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Default)]
 #[cfg_attr(feature = "wasm", derive(ts_rs::TS))]
-#[ts(export)]
+#[cfg_attr(feature = "wasm", ts(export))]
 #[serde(rename_all = "camelCase")]
 pub struct FontScheme {
     pub major_font: FontGroup,

--- a/docx-core/src/documents/elements/font_scheme.rs
+++ b/docx-core/src/documents/elements/font_scheme.rs
@@ -1,6 +1,7 @@
 use serde::Serialize;
 
-#[derive(Debug, Clone, PartialEq, Serialize, ts_rs::TS)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[cfg_attr(feature = "wasm", derive(ts_rs::TS))]
 #[ts(export)]
 #[serde(rename_all = "camelCase")]
 pub struct FontSchemeFont {
@@ -8,7 +9,8 @@ pub struct FontSchemeFont {
     pub typeface: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Default, ts_rs::TS)]
+#[derive(Debug, Clone, PartialEq, Serialize, Default)]
+#[cfg_attr(feature = "wasm", derive(ts_rs::TS))]
 #[ts(export)]
 #[serde(rename_all = "camelCase")]
 pub struct FontGroup {
@@ -18,7 +20,8 @@ pub struct FontGroup {
     pub fonts: Vec<FontSchemeFont>,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Default, ts_rs::TS)]
+#[derive(Debug, Clone, PartialEq, Serialize, Default)]
+#[cfg_attr(feature = "wasm", derive(ts_rs::TS))]
 #[ts(export)]
 #[serde(rename_all = "camelCase")]
 pub struct FontScheme {

--- a/docx-core/src/documents/elements/instr_hyperlink.rs
+++ b/docx-core/src/documents/elements/instr_hyperlink.rs
@@ -3,7 +3,7 @@ use serde::Serialize;
 // https://c-rex.net/projects/samples/ooxml/e1/Part4/OOXML_P4_DOCX_HYPERLINKHYPERLINK_topic_ID0EFYG1.html
 #[derive(Serialize, Debug, Clone, PartialEq, Default)]
 #[cfg_attr(feature = "wasm", derive(ts_rs::TS))]
-#[ts(export)]
+#[cfg_attr(feature = "wasm", ts(export))]
 #[serde(rename_all = "camelCase")]
 pub struct InstrHyperlink {
     pub target: String,

--- a/docx-core/src/documents/elements/instr_hyperlink.rs
+++ b/docx-core/src/documents/elements/instr_hyperlink.rs
@@ -1,7 +1,8 @@
 use serde::Serialize;
 
 // https://c-rex.net/projects/samples/ooxml/e1/Part4/OOXML_P4_DOCX_HYPERLINKHYPERLINK_topic_ID0EFYG1.html
-#[derive(Serialize, Debug, Clone, PartialEq, Default, ts_rs::TS)]
+#[derive(Serialize, Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "wasm", derive(ts_rs::TS))]
 #[ts(export)]
 #[serde(rename_all = "camelCase")]
 pub struct InstrHyperlink {

--- a/docx-core/src/documents/elements/instr_toc.rs
+++ b/docx-core/src/documents/elements/instr_toc.rs
@@ -4,7 +4,7 @@ use crate::documents::*;
 
 #[derive(Serialize, Debug, Clone, PartialEq, Default)]
 #[cfg_attr(feature = "wasm", derive(ts_rs::TS))]
-#[ts(export)]
+#[cfg_attr(feature = "wasm", ts(export))]
 pub struct StyleWithLevel(pub (String, usize));
 
 impl StyleWithLevel {
@@ -15,7 +15,7 @@ impl StyleWithLevel {
 // https://c-rex.net/projects/samples/ooxml/e1/Part4/OOXML_P4_DOCX_TOCTOC_topic_ID0ELZO1.html
 #[derive(Serialize, Debug, Clone, PartialEq, Default)]
 #[cfg_attr(feature = "wasm", derive(ts_rs::TS))]
-#[ts(export)]
+#[cfg_attr(feature = "wasm", ts(export))]
 #[serde(rename_all = "camelCase")]
 pub struct InstrToC {
     // \o If no heading range is specified, all heading levels used in the document are listed.

--- a/docx-core/src/documents/elements/instr_toc.rs
+++ b/docx-core/src/documents/elements/instr_toc.rs
@@ -2,7 +2,8 @@ use serde::Serialize;
 
 use crate::documents::*;
 
-#[derive(Serialize, Debug, Clone, PartialEq, Default, ts_rs::TS)]
+#[derive(Serialize, Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "wasm", derive(ts_rs::TS))]
 #[ts(export)]
 pub struct StyleWithLevel(pub (String, usize));
 
@@ -12,7 +13,8 @@ impl StyleWithLevel {
     }
 }
 // https://c-rex.net/projects/samples/ooxml/e1/Part4/OOXML_P4_DOCX_TOCTOC_topic_ID0ELZO1.html
-#[derive(Serialize, Debug, Clone, PartialEq, Default, ts_rs::TS)]
+#[derive(Serialize, Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "wasm", derive(ts_rs::TS))]
 #[ts(export)]
 #[serde(rename_all = "camelCase")]
 pub struct InstrToC {

--- a/docx-core/src/documents/elements/pic.rs
+++ b/docx-core/src/documents/elements/pic.rs
@@ -7,7 +7,7 @@ use crate::xml_builder::*;
 
 #[derive(Debug, Clone, Serialize, PartialEq)]
 #[cfg_attr(feature = "wasm", derive(ts_rs::TS))]
-#[ts(export)]
+#[cfg_attr(feature = "wasm", ts(export))]
 #[serde(rename_all = "camelCase")]
 pub struct Pic {
     pub id: String,

--- a/docx-core/src/documents/elements/pic.rs
+++ b/docx-core/src/documents/elements/pic.rs
@@ -5,7 +5,8 @@ use crate::documents::*;
 use crate::types::*;
 use crate::xml_builder::*;
 
-#[derive(Debug, Clone, Serialize, PartialEq, ts_rs::TS)]
+#[derive(Debug, Clone, Serialize, PartialEq)]
+#[cfg_attr(feature = "wasm", derive(ts_rs::TS))]
 #[ts(export)]
 #[serde(rename_all = "camelCase")]
 pub struct Pic {

--- a/docx-core/src/documents/elements/shape.rs
+++ b/docx-core/src/documents/elements/shape.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 #[derive(Serialize, Debug, Clone, PartialEq, Default)]
 #[cfg_attr(feature = "wasm", derive(ts_rs::TS))]
-#[ts(export)]
+#[cfg_attr(feature = "wasm", ts(export))]
 #[serde(rename_all = "camelCase")]
 pub struct Shape {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -14,7 +14,7 @@ pub struct Shape {
 
 #[derive(Serialize, Debug, Clone, PartialEq, Default)]
 #[cfg_attr(feature = "wasm", derive(ts_rs::TS))]
-#[ts(export)]
+#[cfg_attr(feature = "wasm", ts(export))]
 #[serde(rename_all = "camelCase")]
 pub struct ImageData {
     pub id: String,

--- a/docx-core/src/documents/elements/shape.rs
+++ b/docx-core/src/documents/elements/shape.rs
@@ -1,6 +1,7 @@
 use serde::Serialize;
 
-#[derive(Serialize, Debug, Clone, PartialEq, Default, ts_rs::TS)]
+#[derive(Serialize, Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "wasm", derive(ts_rs::TS))]
 #[ts(export)]
 #[serde(rename_all = "camelCase")]
 pub struct Shape {
@@ -11,7 +12,8 @@ pub struct Shape {
 }
 // Experimental, For now reader only.
 
-#[derive(Serialize, Debug, Clone, PartialEq, Default, ts_rs::TS)]
+#[derive(Serialize, Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "wasm", derive(ts_rs::TS))]
 #[ts(export)]
 #[serde(rename_all = "camelCase")]
 pub struct ImageData {

--- a/docx-core/src/documents/elements/table_cell_property.rs
+++ b/docx-core/src/documents/elements/table_cell_property.rs
@@ -1,12 +1,13 @@
-use wasm_bindgen::prelude::*;
 use serde::Serialize;
+#[cfg(feature = "wasm")]
+use wasm_bindgen::prelude::*;
 
 use super::*;
 use crate::documents::BuildXML;
 use crate::types::*;
 use crate::xml_builder::*;
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
 #[derive(Serialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct TableCellProperty {

--- a/docx-core/src/documents/elements/table_property.rs
+++ b/docx-core/src/documents/elements/table_property.rs
@@ -1,4 +1,5 @@
 use serde::Serialize;
+#[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::*;
 
 use super::*;
@@ -6,7 +7,7 @@ use crate::documents::BuildXML;
 use crate::types::*;
 use crate::xml_builder::*;
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TableProperty {

--- a/docx-core/src/documents/theme.rs
+++ b/docx-core/src/documents/theme.rs
@@ -2,8 +2,9 @@ use serde::Serialize;
 
 use super::*;
 
-#[derive(Debug, Clone, PartialEq, Serialize, Default, ts_rs::TS)]
-#[ts(export)]
+#[derive(Debug, Clone, PartialEq, Serialize, Default)]
+#[cfg_attr(feature = "wasm", derive(ts_rs::TS))]
+#[cfg_attr(feature = "wasm", ts(export))]
 #[serde(rename_all = "camelCase")]
 pub struct Theme {
     pub font_schema: FontScheme,

--- a/docx-core/src/types/alignment_type.rs
+++ b/docx-core/src/types/alignment_type.rs
@@ -1,10 +1,11 @@
 use std::fmt;
 use std::str::FromStr;
+#[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::*;
 
 use super::errors;
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
 #[derive(Copy, Clone, Debug)]
 pub enum AlignmentType {
     Both,

--- a/docx-core/src/types/border_position.rs
+++ b/docx-core/src/types/border_position.rs
@@ -1,7 +1,8 @@
 use serde::Serialize;
+#[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::*;
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub enum TableBorderPosition {
@@ -13,7 +14,7 @@ pub enum TableBorderPosition {
     InsideV,
 }
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub enum TableCellBorderPosition {

--- a/docx-core/src/types/border_type.rs
+++ b/docx-core/src/types/border_type.rs
@@ -3,12 +3,13 @@
 //
 use serde::{Deserialize, Serialize};
 use std::fmt;
+#[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::*;
 
 use super::errors;
 use std::str::FromStr;
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
 #[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum BorderType {

--- a/docx-core/src/types/break_type.rs
+++ b/docx-core/src/types/break_type.rs
@@ -6,11 +6,12 @@ use serde::{Deserialize, Serialize};
 
 use std::fmt;
 use std::str::FromStr;
+#[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::*;
 
 use super::errors;
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
 #[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub enum BreakType {
     Page,

--- a/docx-core/src/types/doc_grid_type.rs
+++ b/docx-core/src/types/doc_grid_type.rs
@@ -2,11 +2,12 @@ use serde::{Deserialize, Serialize};
 
 use std::fmt;
 use std::str::FromStr;
+#[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::*;
 
 use super::errors;
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
 #[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub enum DocGridType {

--- a/docx-core/src/types/drawing_position.rs
+++ b/docx-core/src/types/drawing_position.rs
@@ -1,9 +1,10 @@
 use serde::Serialize;
 use std::fmt;
 
+#[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::*;
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, ts_rs::TS)]
 #[ts(export)]
 #[serde(rename_all = "camelCase")]
@@ -12,7 +13,7 @@ pub enum DrawingPositionType {
     Inline,
 }
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, ts_rs::TS)]
 #[ts(export)]
 #[serde(rename_all = "camelCase")]

--- a/docx-core/src/types/drawing_position.rs
+++ b/docx-core/src/types/drawing_position.rs
@@ -7,7 +7,7 @@ use wasm_bindgen::prelude::*;
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
 #[derive(Debug, Clone, Copy, Serialize, PartialEq)]
 #[cfg_attr(feature = "wasm", derive(ts_rs::TS))]
-#[ts(export)]
+#[cfg_attr(feature = "wasm", ts(export))]
 #[serde(rename_all = "camelCase")]
 pub enum DrawingPositionType {
     Anchor,
@@ -17,7 +17,7 @@ pub enum DrawingPositionType {
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
 #[derive(Debug, Clone, Copy, Serialize, PartialEq)]
 #[cfg_attr(feature = "wasm", derive(ts_rs::TS))]
-#[ts(export)]
+#[cfg_attr(feature = "wasm", ts(export))]
 #[serde(rename_all = "camelCase")]
 pub enum PicAlign {
     Left,
@@ -41,7 +41,7 @@ impl fmt::Display for PicAlign {
 
 #[derive(Debug, Clone, Copy, Serialize, PartialEq)]
 #[cfg_attr(feature = "wasm", derive(ts_rs::TS))]
-#[ts(export)]
+#[cfg_attr(feature = "wasm", ts(export))]
 #[serde(rename_all = "camelCase")]
 pub enum DrawingPosition {
     Offset(i32),

--- a/docx-core/src/types/drawing_position.rs
+++ b/docx-core/src/types/drawing_position.rs
@@ -5,7 +5,8 @@ use std::fmt;
 use wasm_bindgen::prelude::*;
 
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
-#[derive(Debug, Clone, Copy, Serialize, PartialEq, ts_rs::TS)]
+#[derive(Debug, Clone, Copy, Serialize, PartialEq)]
+#[cfg_attr(feature = "wasm", derive(ts_rs::TS))]
 #[ts(export)]
 #[serde(rename_all = "camelCase")]
 pub enum DrawingPositionType {
@@ -14,7 +15,8 @@ pub enum DrawingPositionType {
 }
 
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
-#[derive(Debug, Clone, Copy, Serialize, PartialEq, ts_rs::TS)]
+#[derive(Debug, Clone, Copy, Serialize, PartialEq)]
+#[cfg_attr(feature = "wasm", derive(ts_rs::TS))]
 #[ts(export)]
 #[serde(rename_all = "camelCase")]
 pub enum PicAlign {
@@ -37,7 +39,8 @@ impl fmt::Display for PicAlign {
     }
 }
 
-#[derive(Debug, Clone, Copy, Serialize, PartialEq, ts_rs::TS)]
+#[derive(Debug, Clone, Copy, Serialize, PartialEq)]
+#[cfg_attr(feature = "wasm", derive(ts_rs::TS))]
 #[ts(export)]
 #[serde(rename_all = "camelCase")]
 pub enum DrawingPosition {

--- a/docx-core/src/types/field_char_type.rs
+++ b/docx-core/src/types/field_char_type.rs
@@ -5,11 +5,12 @@ use serde::{Deserialize, Serialize};
 //
 use std::fmt;
 use std::str::FromStr;
+#[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::*;
 
 use super::errors;
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
 #[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, ts_rs::TS)]
 #[ts(export)]
 #[serde(rename_all = "camelCase")]

--- a/docx-core/src/types/field_char_type.rs
+++ b/docx-core/src/types/field_char_type.rs
@@ -11,7 +11,8 @@ use wasm_bindgen::prelude::*;
 use super::errors;
 
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
-#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, ts_rs::TS)]
+#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[cfg_attr(feature = "wasm", derive(ts_rs::TS))]
 #[ts(export)]
 #[serde(rename_all = "camelCase")]
 pub enum FieldCharType {

--- a/docx-core/src/types/field_char_type.rs
+++ b/docx-core/src/types/field_char_type.rs
@@ -13,7 +13,7 @@ use super::errors;
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
 #[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[cfg_attr(feature = "wasm", derive(ts_rs::TS))]
-#[ts(export)]
+#[cfg_attr(feature = "wasm", ts(export))]
 #[serde(rename_all = "camelCase")]
 pub enum FieldCharType {
     Begin,

--- a/docx-core/src/types/font_pitch_type.rs
+++ b/docx-core/src/types/font_pitch_type.rs
@@ -1,7 +1,8 @@
 use std::fmt;
+#[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::*;
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
 #[derive(Copy, Clone, Debug)]
 pub enum FontPitchType {
     Default,

--- a/docx-core/src/types/height_rule.rs
+++ b/docx-core/src/types/height_rule.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+#[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::*;
 
 use serde::Serialize;
@@ -6,7 +7,7 @@ use serde::Serialize;
 use super::errors;
 use std::str::FromStr;
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
 #[derive(Debug, Clone, Copy, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub enum HeightRule {

--- a/docx-core/src/types/hyperlink_type.rs
+++ b/docx-core/src/types/hyperlink_type.rs
@@ -8,7 +8,8 @@ use super::errors;
 use std::str::FromStr;
 
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
-#[derive(Debug, Clone, PartialEq, Serialize, ts_rs::TS)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[cfg_attr(feature = "wasm", derive(ts_rs::TS))]
 #[serde(rename_all = "camelCase")]
 #[ts(export)]
 pub enum HyperlinkType {

--- a/docx-core/src/types/hyperlink_type.rs
+++ b/docx-core/src/types/hyperlink_type.rs
@@ -11,7 +11,7 @@ use std::str::FromStr;
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[cfg_attr(feature = "wasm", derive(ts_rs::TS))]
 #[serde(rename_all = "camelCase")]
-#[ts(export)]
+#[cfg_attr(feature = "wasm", ts(export))]
 pub enum HyperlinkType {
     Anchor,
     External,

--- a/docx-core/src/types/hyperlink_type.rs
+++ b/docx-core/src/types/hyperlink_type.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+#[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::*;
 
 use serde::Serialize;
@@ -6,7 +7,7 @@ use serde::Serialize;
 use super::errors;
 use std::str::FromStr;
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
 #[derive(Debug, Clone, PartialEq, Serialize, ts_rs::TS)]
 #[serde(rename_all = "camelCase")]
 #[ts(export)]

--- a/docx-core/src/types/level_suffix_type.rs
+++ b/docx-core/src/types/level_suffix_type.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+#[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::*;
 
 use serde::Serialize;
@@ -6,7 +7,7 @@ use serde::Serialize;
 use super::errors;
 use std::str::FromStr;
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub enum LevelSuffixType {

--- a/docx-core/src/types/line_spacing_type.rs
+++ b/docx-core/src/types/line_spacing_type.rs
@@ -2,9 +2,10 @@ use crate::types::errors;
 use crate::TypeError;
 use serde::*;
 use std::str::FromStr;
+#[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::*;
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
 #[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum LineSpacingType {

--- a/docx-core/src/types/page_orientation_type.rs
+++ b/docx-core/src/types/page_orientation_type.rs
@@ -2,11 +2,12 @@ use serde::{Deserialize, Serialize};
 
 use std::fmt;
 use std::str::FromStr;
+#[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::*;
 
 use super::errors;
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
 #[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub enum PageOrientationType {

--- a/docx-core/src/types/relative_from_type.rs
+++ b/docx-core/src/types/relative_from_type.rs
@@ -11,7 +11,7 @@ use std::str::FromStr;
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
 #[derive(Debug, Clone, Copy, PartialEq, Serialize)]
 #[cfg_attr(feature = "wasm", derive(ts_rs::TS))]
-#[ts(export)]
+#[cfg_attr(feature = "wasm", ts(export))]
 #[serde(rename_all = "camelCase")]
 pub enum RelativeFromHType {
     /// Specifies that the horizontal positioning shall be
@@ -85,7 +85,7 @@ impl FromStr for RelativeFromHType {
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
 #[derive(Debug, Clone, Copy, PartialEq, Serialize)]
 #[cfg_attr(feature = "wasm", derive(ts_rs::TS))]
-#[ts(export)]
+#[cfg_attr(feature = "wasm", ts(export))]
 #[serde(rename_all = "camelCase")]
 pub enum RelativeFromVType {
     BottomMargin,

--- a/docx-core/src/types/relative_from_type.rs
+++ b/docx-core/src/types/relative_from_type.rs
@@ -9,7 +9,8 @@ use std::str::FromStr;
 
 // @See: 20.4.3.4 ST_RelFromH (Horizontal Relative Positioning)
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
-#[derive(Debug, Clone, Copy, PartialEq, Serialize, ts_rs::TS)]
+#[derive(Debug, Clone, Copy, PartialEq, Serialize)]
+#[cfg_attr(feature = "wasm", derive(ts_rs::TS))]
 #[ts(export)]
 #[serde(rename_all = "camelCase")]
 pub enum RelativeFromHType {
@@ -82,7 +83,8 @@ impl FromStr for RelativeFromHType {
 }
 
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
-#[derive(Debug, Clone, Copy, PartialEq, Serialize, ts_rs::TS)]
+#[derive(Debug, Clone, Copy, PartialEq, Serialize)]
+#[cfg_attr(feature = "wasm", derive(ts_rs::TS))]
 #[ts(export)]
 #[serde(rename_all = "camelCase")]
 pub enum RelativeFromVType {

--- a/docx-core/src/types/relative_from_type.rs
+++ b/docx-core/src/types/relative_from_type.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+#[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::*;
 
 use serde::Serialize;
@@ -7,7 +8,7 @@ use super::errors;
 use std::str::FromStr;
 
 // @See: 20.4.3.4 ST_RelFromH (Horizontal Relative Positioning)
-#[wasm_bindgen]
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, ts_rs::TS)]
 #[ts(export)]
 #[serde(rename_all = "camelCase")]
@@ -80,7 +81,7 @@ impl FromStr for RelativeFromHType {
     }
 }
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, ts_rs::TS)]
 #[ts(export)]
 #[serde(rename_all = "camelCase")]

--- a/docx-core/src/types/section_type.rs
+++ b/docx-core/src/types/section_type.rs
@@ -11,11 +11,12 @@ use serde::{Deserialize, Serialize};
 
 use std::fmt;
 use std::str::FromStr;
+#[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::*;
 
 use super::errors;
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
 #[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub enum SectionType {

--- a/docx-core/src/types/shd_type.rs
+++ b/docx-core/src/types/shd_type.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use std::fmt;
 use std::str::FromStr;
+#[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::*;
 
 use super::errors;
@@ -46,7 +47,7 @@ use super::errors;
 <xsd:enumeration value="pct90"/>
 <xsd:enumeration value="pct95"/>
 */
-#[wasm_bindgen]
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
 #[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub enum ShdType {

--- a/docx-core/src/types/special_indent_type.rs
+++ b/docx-core/src/types/special_indent_type.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::*;
 
 use serde::ser::{SerializeStruct, Serializer};
@@ -11,7 +12,7 @@ pub enum SpecialIndentType {
     Hanging(i32),
 }
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
 #[derive(Serialize, Copy, Clone, Debug)]
 pub enum SpecialIndentKind {
     FirstLine,

--- a/docx-core/src/types/style_type.rs
+++ b/docx-core/src/types/style_type.rs
@@ -1,11 +1,12 @@
 use std::fmt;
+#[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::*;
 
 use super::errors;
 use serde::Serialize;
 use std::str::FromStr;
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
 #[derive(Debug, Clone, PartialEq, Serialize, Copy)]
 #[serde(rename_all = "camelCase")]
 pub enum StyleType {

--- a/docx-core/src/types/tab_leader_type.rs
+++ b/docx-core/src/types/tab_leader_type.rs
@@ -2,11 +2,12 @@ use serde::{Deserialize, Serialize};
 
 use std::fmt;
 use std::str::FromStr;
+#[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::*;
 
 use super::errors;
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
 #[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub enum TabLeaderType {

--- a/docx-core/src/types/tab_value_type.rs
+++ b/docx-core/src/types/tab_value_type.rs
@@ -2,11 +2,12 @@ use serde::{Deserialize, Serialize};
 
 use std::fmt;
 use std::str::FromStr;
+#[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::*;
 
 use super::errors;
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
 #[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub enum TabValueType {

--- a/docx-core/src/types/table_alignment_type.rs
+++ b/docx-core/src/types/table_alignment_type.rs
@@ -1,10 +1,11 @@
 use std::fmt;
 use std::str::FromStr;
+#[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::*;
 
 use super::errors;
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
 #[derive(Copy, Clone, Debug)]
 pub enum TableAlignmentType {
     Center,

--- a/docx-core/src/types/table_layout_type.rs
+++ b/docx-core/src/types/table_layout_type.rs
@@ -1,11 +1,12 @@
 use serde::{Deserialize, Serialize};
 use std::fmt;
+#[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::*;
 
 use super::errors;
 use std::str::FromStr;
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
 #[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum TableLayoutType {

--- a/docx-core/src/types/text_direction_type.rs
+++ b/docx-core/src/types/text_direction_type.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+#[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::*;
 
 use serde::Serialize;
@@ -8,7 +9,7 @@ use std::str::FromStr;
 
 // ST_TextDirection defines `lr`, `lrV`, `rl`, `rlV`, `tb`, `tbV`.
 // However Microsoft word use `tbRlV`, `tbRl`, `btLr`, `lrTbV`.
-#[wasm_bindgen]
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
 #[derive(Debug, Clone, Copy, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub enum TextDirectionType {

--- a/docx-core/src/types/vert_align_type.rs
+++ b/docx-core/src/types/vert_align_type.rs
@@ -1,10 +1,11 @@
 use std::fmt;
 use std::str::FromStr;
+#[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::*;
 
 use super::errors;
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum VertAlignType {
     Baseline,

--- a/docx-core/src/types/vertical_align_type.rs
+++ b/docx-core/src/types/vertical_align_type.rs
@@ -1,10 +1,11 @@
 use std::fmt;
+#[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::*;
 
 use super::errors;
 use std::str::FromStr;
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum VAlignType {
     Top,

--- a/docx-core/src/types/vertical_merge_type.rs
+++ b/docx-core/src/types/vertical_merge_type.rs
@@ -1,10 +1,11 @@
 use std::fmt;
+#[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::*;
 
 use super::errors;
 use std::str::FromStr;
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum VMergeType {
     Continue,

--- a/docx-core/src/types/width_type.rs
+++ b/docx-core/src/types/width_type.rs
@@ -1,11 +1,12 @@
 use serde::Serialize;
 use std::fmt;
+#[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::*;
 
 use super::errors;
 use std::str::FromStr;
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
 #[derive(Copy, Clone, Debug, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub enum WidthType {

--- a/docx-wasm/Cargo.toml
+++ b/docx-wasm/Cargo.toml
@@ -12,4 +12,4 @@ crate-type = ["cdylib"]
 [dependencies]
 wasm-bindgen = "0.2.78"
 console_error_panic_hook = "0.1.7"
-docx-rs= { path = "../docx-core" }
+docx-rs= { path = "../docx-core", features = ["wasm"] }


### PR DESCRIPTION
## What does this change?

Puts wasm related code behind a feature gate so that users who do not need this feature do not need to compile it

## References

I didn't take a note of the first search/replace but here are the others that i did:

all within docx-core/
```
search
#\[derive\((.*) ts_rs::TS\)\]

replace
#[derive($1)]\n#[cfg_attr(feature = "wasm", derive(ts_rs::TS))]

--

search
#[ts(export)]

replace
#[cfg_attr(feature = "wasm", ts(export))]
```

## Misc

- THIS PR CURRENTLY BREAKS TESTS. please advise, I'm not sure what I have done wrong.
- I did not put serde_json behind the feature flag, not sure if it is used in the case of wasm only.
- Users who pull in docx-rs with `default-features = false` AND rely on wasm, this will be a breaking change for them. 