### PR TITLE
Add Support for Parsing Lists

### DIFF
--- a/docx-core/src/documents/elements/abstract_numbering.rs
+++ b/docx-core/src/documents/elements/abstract_numbering.rs
@@ -6,10 +6,10 @@ use serde::Serialize;
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AbstractNumbering {
-    id: usize,
-    style_link: Option<String>,
-    num_style_link: Option<String>,
-    levels: Vec<Level>,
+    pub id: usize,
+    pub style_link: Option<String>,
+    pub num_style_link: Option<String>,
+    pub levels: Vec<Level>,
 }
 
 impl AbstractNumbering {

--- a/docx-core/src/documents/elements/number_format.rs
+++ b/docx-core/src/documents/elements/number_format.rs
@@ -5,7 +5,7 @@ use crate::xml_builder::*;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct NumberFormat {
-    val: String,
+    pub val: String,
 }
 
 impl NumberFormat {

--- a/docx-core/src/documents/elements/numbering.rs
+++ b/docx-core/src/documents/elements/numbering.rs
@@ -7,8 +7,8 @@ use serde::Serialize;
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Numbering {
-    id: usize,
-    abstract_num_id: usize,
+    pub id: usize,
+    pub abstract_num_id: usize,
     pub level_overrides: Vec<LevelOverride>,
 }
 

--- a/docx-core/src/documents/numberings.rs
+++ b/docx-core/src/documents/numberings.rs
@@ -8,8 +8,8 @@ use serde::Serialize;
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Numberings {
-    abstract_nums: Vec<AbstractNumbering>,
-    numberings: Vec<Numbering>,
+    pub abstract_nums: Vec<AbstractNumbering>,
+    pub numberings: Vec<Numbering>,
 }
 
 impl Numberings {


### PR DESCRIPTION
## What does this change?

Made the numbering structs public, to be able to parse lists in docx files using the docx-rs api, without generating to json.

## References

- If you have links to other resources, please list them here. (e.g. issue url, related pull request url, documents)

## Screenshots

If applicable, add screenshots to help explain your changes.

## What can I check for bug fixes?

Please briefly describe how you can confirm the resolution of the bug.
