### PR TITLE
fix: add `w:caps` property to to `w:rPr` element

### DIFF
--- a/docx-core/src/documents/elements/caps.rs
+++ b/docx-core/src/documents/elements/caps.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize, Serializer};
 
+use crate::{xml_builder::XMLBuilder, BuildXML};
+
 // use crate::documents::BuildXML;
 // use crate::xml_builder::*;
 
@@ -31,5 +33,12 @@ impl Serialize for Caps {
         S: Serializer,
     {
         serializer.serialize_bool(self.val)
+    }
+}
+
+impl BuildXML for Caps {
+    fn build(&self) -> Vec<u8> {
+        let b = XMLBuilder::new();
+        b.caps().build()
     }
 }

--- a/docx-core/src/documents/elements/caps.rs
+++ b/docx-core/src/documents/elements/caps.rs
@@ -39,6 +39,6 @@ impl Serialize for Caps {
 impl BuildXML for Caps {
     fn build(&self) -> Vec<u8> {
         let b = XMLBuilder::new();
-        b.caps().build()
+        b.caps(&self.val.to_string()).build()
     }
 }

--- a/docx-core/src/documents/elements/run_property.rs
+++ b/docx-core/src/documents/elements/run_property.rs
@@ -165,6 +165,7 @@ impl BuildXML for RunProperty {
             .add_optional_child(&self.color)
             .add_optional_child(&self.bold)
             .add_optional_child(&self.bold_cs)
+            .add_optional_child(&self.caps)
             .add_optional_child(&self.italic)
             .add_optional_child(&self.italic_cs)
             .add_optional_child(&self.strike)

--- a/docx-core/src/xml_builder/elements.rs
+++ b/docx-core/src/xml_builder/elements.rs
@@ -179,6 +179,8 @@ impl XMLBuilder {
     closed!(b, "w:b");
     closed!(b_cs, "w:bCs");
 
+    closed!(caps, "w:caps");
+
     closed!(i, "w:i");
     closed!(i_cs, "w:iCs");
 

--- a/docx-core/src/xml_builder/elements.rs
+++ b/docx-core/src/xml_builder/elements.rs
@@ -179,7 +179,7 @@ impl XMLBuilder {
     closed!(b, "w:b");
     closed!(b_cs, "w:bCs");
 
-    closed!(caps, "w:caps");
+    closed_with_str!(caps, "w:caps");
 
     closed!(i, "w:i");
     closed!(i_cs, "w:iCs");


### PR DESCRIPTION
## What does this change?

Run elements `w:rPr` do not build their `caps` property if it is a non-optional value.

Summary:
- Implemented `BuildXml` for `Caps`
- Added `self.caps` property on `build()` function for RunProperty
- `XMLBuilder` has a new method named `caps` via the `closed_with_str!` macro

## References
[Microsoft - Primary Source](https://learn.microsoft.com/en-us/dotnet/api/documentformat.openxml.wordprocessing.caps?view=openxml-3.0.1)

Secondary sources:
http://www.datypic.com/sc/ooxml/e-w_caps-1.html
http://officeopenxml.com/WPtextFormatting.php

## Example
```rust
pub(crate) fn caps_style() {
    let mut caps = Style::new("Caps", StyleType::Character)
        .name("Caps")
        .based_on("DefaultParagraphFont");

    caps.run_property = RunProperty::new().caps();

    let docx = Docx::new().add_style(caps).add_paragraph(
        Paragraph::new().add_run(Run::new().add_text("This should be all caps").style("Caps")),
    );

    let docx_output = File::create(Path::new("caps_style.docx")).unwrap();

    docx.build().pack(docx_output).unwrap();
}
```
Results in the following snippet in `styles.xml`:
```xml
    <w:style w:type="character" w:styleId="Caps">
        <w:name w:val="Caps" />
        <w:rPr />
        <w:pPr>
            <w:rPr />
        </w:pPr>
        <w:qFormat />
        <w:basedOn w:val="DefaultParagraphFont" />
    </w:style>
```
![image](https://github.com/bokuweb/docx-rs/assets/44790295/aa2f1479-d66b-4064-b1bd-b97574d584c7)

## Working example with this PR
```rust
//same code as above
```
Results in
```xml
    <w:style w:type="character" w:styleId="Caps">
        <w:name w:val="Caps" />
        <w:rPr>
            <w:caps w:val="true" />
        </w:rPr>
        <w:pPr>
            <w:rPr />
        </w:pPr>
        <w:qFormat />
        <w:basedOn w:val="DefaultParagraphFont" />
    </w:style>
```
![image](https://github.com/bokuweb/docx-rs/assets/44790295/109454e6-cc9b-44e8-840e-bd7ad4886637)


## What can I check for bug fixes?
Yes, please let me know what you would like to verify this behavior!
