### PR TITLE
Run level shading

### DIFF
--- a/docx-core/src/documents/elements/run.rs
+++ b/docx-core/src/documents/elements/run.rs
@@ -40,6 +40,7 @@ pub enum RunChild {
     // For reader
     InstrTextString(String),
     FootnoteReference(FootnoteReference),
+    Shading(Shading),
 }
 
 impl Serialize for RunChild {
@@ -128,6 +129,12 @@ impl Serialize for RunChild {
             RunChild::FootnoteReference(ref f) => {
                 let mut t = serializer.serialize_struct("FootnoteReference", 2)?;
                 t.serialize_field("type", "footnoteReference")?;
+                t.serialize_field("data", f)?;
+                t.end()
+            }
+            RunChild::Shading(ref f) => {
+                let mut t = serializer.serialize_struct("Shading", 2)?;
+                t.serialize_field("type", "shading")?;
                 t.serialize_field("data", f)?;
                 t.end()
             }
@@ -297,6 +304,11 @@ impl Run {
             .push(RunChild::FootnoteReference(footnote.into()));
         self
     }
+
+    pub fn shading(mut self, shading: Shading) -> Run {
+        self.run_property = self.run_property.shading(shading);
+        self
+    }
 }
 
 impl BuildXML for Run {
@@ -321,6 +333,7 @@ impl BuildXML for Run {
                 RunChild::DeleteInstrText(c) => b = b.add_child(c),
                 RunChild::InstrTextString(_) => unreachable!(),
                 RunChild::FootnoteReference(c) => b = b.add_child(c),
+                RunChild::Shading(s) => b = b.add_child(s),
             }
         }
         b.close().build()
@@ -398,6 +411,15 @@ mod tests {
         assert_eq!(
             serde_json::to_string(&c).unwrap(),
             r#"{"type":"footnoteReference","data":{"id":1}}"#
+        );
+    }
+
+    #[test]
+    fn test_run_shading() {
+        let c = RunChild::Shading(Shading::new());
+        assert_eq!(
+            serde_json::to_string(&c).unwrap(),
+            r#"{"type":"shading","data":{"shdType":"clear","color":"auto","fill":"FFFFFF"}}"#
         );
     }
 }

--- a/docx-core/src/documents/elements/run_property.rs
+++ b/docx-core/src/documents/elements/run_property.rs
@@ -48,6 +48,8 @@ pub struct RunProperty {
     pub ins: Option<Insert>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub strike: Option<Strike>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub shading: Option<Shading>,
 }
 
 impl RunProperty {
@@ -154,6 +156,11 @@ impl RunProperty {
         self.ins = Some(i);
         self
     }
+
+    pub fn shading(mut self, s: Shading) -> Self {
+        self.shading = Some(s);
+        self
+    }
 }
 
 impl BuildXML for RunProperty {
@@ -180,6 +187,7 @@ impl BuildXML for RunProperty {
             .add_optional_child(&self.vert_align)
             .add_optional_child(&self.character_spacing)
             .add_optional_child(&self.style)
+            .add_optional_child(&self.shading)
             .close()
             .build()
     }
@@ -269,6 +277,21 @@ mod tests {
         assert_eq!(
             str::from_utf8(&b).unwrap(),
             r#"<w:rPr><w:spacing w:val="20" /></w:rPr>"#
+        );
+    }
+
+    #[test]
+    fn test_character_shading() {
+        let c = RunProperty::new().shading(
+            Shading::new()
+                .shd_type(ShdType::Clear)
+                .fill("FFFFFF")
+                .color("auto"),
+        );
+        let b = c.build();
+        assert_eq!(
+            str::from_utf8(&b).unwrap(),
+            r#"<w:rPr><w:shd w:val="clear" w:color="auto" w:fill="FFFFFF" /></w:rPr>"#
         );
     }
 }


### PR DESCRIPTION
## What does this change?

Add initial support for `Shading` at the `Run` level. Attempt to fix https://github.com/bokuweb/docx-rs/issues/719.
This focuses on the rust-side of the code - i.e docx-core - but docx-wasm tests seem to pass.

## References

- See https://github.com/bokuweb/docx-rs/issues/719 for details.

## Screenshots

Not applicable

## What can I check for bug fixes?

Not applicable