### PR TITLE
Support strike at Run level: add strike() to Run

### DIFF
--- a/docx-core/src/documents/elements/run.rs
+++ b/docx-core/src/documents/elements/run.rs
@@ -261,6 +261,11 @@ impl Run {
         self
     }
 
+    pub fn strike(mut self) -> Run {
+        self.run_property = self.run_property.strike();
+        self
+    }
+
     pub fn text_border(mut self, b: TextBorder) -> Run {
         self.run_property = self.run_property.text_border(b);
         self
@@ -350,6 +355,15 @@ mod tests {
         assert_eq!(
             str::from_utf8(&b).unwrap(),
             r#"<w:r><w:rPr><w:u w:val="single" /></w:rPr><w:t xml:space="preserve">Hello</w:t></w:r>"#
+        );
+    }
+
+    #[test]
+    fn test_strike() {
+        let b = Run::new().add_text("Hello").strike().build();
+        assert_eq!(
+            str::from_utf8(&b).unwrap(),
+            r#"<w:r><w:rPr><w:strike /></w:rPr><w:t xml:space="preserve">Hello</w:t></w:r>"#
         );
     }
 


### PR DESCRIPTION
## What does this change?

Add support for `strike()` at the `Run` level. Attempt to fix https://github.com/bokuweb/docx-rs/issues/647.
This focuses on the rust-side of the code - i.e docx-core - but docx-wasm tests seem to pass.

## References

- See https://github.com/bokuweb/docx-rs/issues/647 for details.

## Screenshots

Not applicable

## What can I check for bug fixes?

Not applicable