### PR TITLE
Make 'image' crate optional

### DIFF
--- a/docx-core/Cargo.toml
+++ b/docx-core/Cargo.toml
@@ -18,7 +18,8 @@ name = "docx_rs"
 path = "src/lib.rs"
 
 [features]
-wasm = ["wasm-bindgen", "ts-rs"]
+default = ["image"]
+wasm = ["wasm-bindgen", "ts-rs", "image"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -29,7 +30,7 @@ zip = { version = "0.6.3", default-features = false, features = ["deflate"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = {version = "1.0" }
 base64 = "0.13.1"
-image = { version = "0.24.4", default-features = false, features=["gif", "jpeg", "png", "bmp", "tiff"] }
+image = { version = "0.24.4", default-features = false, features=["gif", "jpeg", "png", "bmp", "tiff"], optional = true }
 wasm-bindgen = { version = "0.2.78", optional = true }
 ts-rs = { version = "6.1", optional = true }
 

--- a/docx-core/src/documents/elements/drawing.rs
+++ b/docx-core/src/documents/elements/drawing.rs
@@ -163,12 +163,8 @@ mod tests {
 
     #[test]
     fn test_drawing_build_with_pic() {
-        use std::io::Read;
-
-        let mut img = std::fs::File::open("../images/cat_min.jpg").unwrap();
-        let mut buf = Vec::new();
-        let _ = img.read_to_end(&mut buf).unwrap();
-        let d = Drawing::new().pic(Pic::new(&buf)).build();
+        let pic = Pic::new_with_dimensions(Vec::new(), 320, 240);
+        let d = Drawing::new().pic(pic).build();
         assert_eq!(
             str::from_utf8(&d).unwrap(),
             r#"<w:drawing>
@@ -212,12 +208,8 @@ mod tests {
 
     #[test]
     fn test_drawing_build_with_pic_overlap() {
-        use std::io::Read;
-
-        let mut img = std::fs::File::open("../images/cat_min.jpg").unwrap();
-        let mut buf = Vec::new();
-        let _ = img.read_to_end(&mut buf).unwrap();
-        let d = Drawing::new().pic(Pic::new(&buf).overlapping()).build();
+        let pic = Pic::new_with_dimensions(Vec::new(), 320, 240).overlapping();
+        let d = Drawing::new().pic(pic).build();
         assert_eq!(
             str::from_utf8(&d).unwrap(),
             r#"<w:drawing>
@@ -262,12 +254,7 @@ mod tests {
 
     #[test]
     fn test_drawing_build_with_pic_align_right() {
-        use std::io::Read;
-
-        let mut img = std::fs::File::open("../images/cat_min.jpg").unwrap();
-        let mut buf = Vec::new();
-        let _ = img.read_to_end(&mut buf).unwrap();
-        let mut pic = Pic::new(&buf).floating();
+        let mut pic = Pic::new_with_dimensions(Vec::new(), 320, 240).floating();
         pic = pic.relative_from_h(RelativeFromHType::Column);
         pic = pic.relative_from_v(RelativeFromVType::Paragraph);
         pic = pic.position_h(DrawingPosition::Align(PicAlign::Right));
@@ -323,12 +310,7 @@ mod tests {
 
     #[test]
     fn test_issue686() {
-        use std::io::Read;
-
-        let mut img = std::fs::File::open("../images/cat_min.jpg").unwrap();
-        let mut buf = Vec::new();
-        let _ = img.read_to_end(&mut buf).unwrap();
-        let pic = Pic::new(&buf)
+        let pic = Pic::new_with_dimensions(Vec::new(), 320, 240)
             .size(320 * 9525, 240 * 9525)
             .floating()
             .offset_x(300 * 9525)


### PR DESCRIPTION
Discussion at #763.

```
#[derive(Debug, Clone, Serialize)]
#[serde(rename_all = "camelCase")]
pub struct Docx {
   ...
    // reader only
    pub images: Vec<(String, String, Image, Png)>,
}
```

Is `Png` really needed here? Why not just `Image`? The end user may convert buffer themselves…