### PR TITLE
ci: upgrade setup-node to v4 and node-version to v20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
-      - uses: actions/setup-node@master
+      - uses: actions/setup-node@v4
         with:
-          node-version: 14
+          node-version: 20
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -68,9 +68,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@master
+      - uses: actions/setup-node@v4
         with:
-          node-version: 14
+          node-version: 20
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal


### PR DESCRIPTION
## What does this change?

Use setup-node v4 and upgrade the node version to v20.

## References

N/A

## Screenshots

N/A

## What can I check for bug fixes?

Please briefly describe how you can confirm the resolution of the bug.
