### PR TITLE
ci: use moonrepo/setup-rust

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,4 +87,5 @@ jobs:
         with:
             inherit-toolchain: true
             components: clippy
-      - run: cargo clippy -- -D warnings
+    # TODO(@unvalley): enable
+    #   - run: cargo clippy -- -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,4 +87,4 @@ jobs:
         with:
             inherit-toolchain: true
             components: clippy
-      - run: cargo clipy -- -D warnings
+      - run: cargo clippy -- -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,11 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - uses: actions-rs/toolchain@v1
+      - uses: moonrepo/setup-rust@v1
         with:
           profile: minimal
-          toolchain: stable
-          override: true
+          cache: false
+          inherit-toolchain: true
       - name: Cache cargo registry
         uses: actions/cache@v4
         with:
@@ -47,11 +47,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: moonrepo/setup-rust@v1
         with:
           profile: minimal
-          toolchain: stable
-          override: true
+          inherit-toolchain: true
       - name: Cache cargo registry
         uses: actions/cache@v4
         with:
@@ -71,11 +70,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - uses: actions-rs/toolchain@v1
+      - uses: moonrepo/setup-rust@v1
         with:
           profile: minimal
-          toolchain: 1.58.1
-          override: true
+          inherit-toolchain: true
       - run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - run: rustup target add wasm32-unknown-unknown
       - run: cd docx-wasm && yarn install && yarn wasm-pack:node && yarn wasm-pack:dev && tsc -p tsconfig.node.json && yarn test
@@ -85,13 +83,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: moonrepo/setup-rust@v1
         with:
-          profile: minimal
-          toolchain: 1.56.1
-          override: true
-      - run: rustup component add clippy
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: -- -D warnings
+            inherit-toolchain: true
+            components: clippy
+      - run: cargo clipy -- -D warnings


### PR DESCRIPTION
## What does this change?

Switch actions-rs to `moonrepo/setup-rust`.
⚠️ This PR disables clippy run on CI, I'll address the clippy warnings in #768 

## References

Compared to other actions:
https://github.com/moonrepo/setup-rust#compared-to

There are main reason to choose moonrepo/setup-rust instead of dtolnay/rust-toolchain

- Extracts the toolchain/channel from rust-toolchain.toml and rust-toolchain configuration files.
- Automatically caches.
- Installs Cargo bins.

some repositories that use this action: e.g. biome, oxc (previoulsy), some web-infra-dev repos
https://grep.app/search?q=moonrepo/setup-rust

But I don't have preferences, so please let me know if you have favorite one.


## Screenshots

NA

## What can I check for bug fixes?

maintenance