### PR TITLE
update table_cell_width, table_indent

### DIFF
--- a/docx-core/src/documents/elements/table_cell_width.rs
+++ b/docx-core/src/documents/elements/table_cell_width.rs
@@ -24,7 +24,7 @@ impl BuildXML for TableCellWidth {
         stream: xml::writer::EventWriter<W>,
     ) -> xml::writer::Result<xml::writer::EventWriter<W>> {
         XMLBuilder::from(stream)
-            .table_cell_width(self.width as i32, WidthType::Dxa)?
+            .table_cell_width(self.width as i32, self.width_type)?
             .into_inner()
     }
 }

--- a/docx-core/src/documents/elements/table_indent.rs
+++ b/docx-core/src/documents/elements/table_indent.rs
@@ -24,7 +24,7 @@ impl BuildXML for TableIndent {
         stream: xml::writer::EventWriter<W>,
     ) -> xml::writer::Result<xml::writer::EventWriter<W>> {
         XMLBuilder::from(stream)
-            .table_indent(self.width, WidthType::Dxa)?
+            .table_indent(self.width, self.width_type)?
             .into_inner()
     }
 }


### PR DESCRIPTION
## What does this change?

This change allows `TableCellWidth` and `TableIndent` to use own `WidthType` instead of being fixed to `WidthType::Dxa`.

## References

- #722

## Screenshots



## What can I check for bug fixes?

```rust
use docx_rs::*;

fn main() -> Result<(), DocxError> {
    let path = std::path::Path::new("./hello.docx");
    let file = std::fs::File::create(path).unwrap();

    Docx::new()
        .add_table(
            Table::new(Vec::from([TableRow::new(Vec::from([
                TableCell::new()
                    .add_paragraph(Paragraph::new().add_run(Run::new().add_text("Cell 1")))
                    .width(2000, WidthType::Pct),
                TableCell::new()
                    .add_paragraph(Paragraph::new().add_run(Run::new().add_text("Cell 2")))
                    .width(3000, WidthType::Pct),
            ]))]))
            .width(5000, WidthType::Pct),
        )
        .build()
        .pack(file)?;
    Ok(())
}
```
