### PR TITLE
Bidi Support

### DIFF
--- a/docx-core/src/documents/elements/paragraph_property.rs
+++ b/docx-core/src/documents/elements/paragraph_property.rs
@@ -25,6 +25,8 @@ pub struct ParagraphProperty {
     pub keep_next: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub keep_lines: Option<bool>,
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub bidi:Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub page_break_before: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -131,7 +133,10 @@ impl ParagraphProperty {
         self.page_break_before = Some(v);
         self
     }
-
+    pub fn bidi(mut self,v:bool)->Self{
+        self.bidi=Some(v);
+        self
+    }
     pub fn widow_control(mut self, v: bool) -> Self {
         self.widow_control = Some(v);
         self
@@ -230,6 +235,7 @@ impl BuildXML for ParagraphProperty {
             .apply_if(self.keep_next, |b| b.keep_next())?
             .apply_if(self.keep_lines, |b| b.keep_lines())?
             .apply_if(self.page_break_before, |b| b.page_break_before())?
+            .apply_if(self.bidi,|b| b.bidi())?
             .apply_opt(self.widow_control, |flag, b| {
                 b.widow_control(if flag { "1" } else { "0" })
             })?
@@ -258,6 +264,13 @@ mod tests {
         assert_eq!(str::from_utf8(&b).unwrap(), r#"<w:pPr><w:rPr /></w:pPr>"#);
     }
 
+    #[test]
+    fn test_bidi(){
+        let c=ParagraphProperty::new().bidi(true);
+        let b=c.build();
+        println!("-----Test bidi: {}", str::from_utf8(&b).unwrap());
+        assert_eq!(str::from_utf8(&b).unwrap(),r#"<w:pPr><w:rPr /><w:bidi /></w:pPr>"#);
+    }
     #[test]
     fn test_alignment() {
         let c = ParagraphProperty::new();

--- a/docx-core/src/xml_builder/elements.rs
+++ b/docx-core/src/xml_builder/elements.rs
@@ -470,7 +470,7 @@ impl<W: Write> XMLBuilder<W> {
     closed!(keep_lines, "w:keepLines");
     closed!(page_break_before, "w:pageBreakBefore");
     closed!(widow_control, "w:widowControl", "w:val");
-
+    closed!(bidi,"w:bidi");
     /*
     <w:lvlOverride w:ilvl="0">
       <w:startOverride w:val="1"/>


### PR DESCRIPTION
Added a simple bidi support by new paragraph property called bidi Works as a boolean flag when available MS Word treats the paragraph as RTL, otherwise it's LTR

## What does this change?

Added a new flag called `bidi` in ParagraphProperty which is set to allow simple bidi support in the resulting docx file
