### PR TITLE
Change Style RunProperty internal structs val to public

### DIFF
--- a/docx-core/src/documents/elements/bold.rs
+++ b/docx-core/src/documents/elements/bold.rs
@@ -6,7 +6,7 @@ use crate::xml_builder::*;
 
 #[derive(Debug, Clone, Deserialize, PartialEq)]
 pub struct Bold {
-    val: bool,
+    pub val: bool,
 }
 
 impl Bold {

--- a/docx-core/src/documents/elements/bold_cs.rs
+++ b/docx-core/src/documents/elements/bold_cs.rs
@@ -6,7 +6,7 @@ use crate::xml_builder::*;
 
 #[derive(Debug, Clone, Deserialize, PartialEq)]
 pub struct BoldCs {
-    val: bool,
+    pub val: bool,
 }
 
 impl BoldCs {

--- a/docx-core/src/documents/elements/caps.rs
+++ b/docx-core/src/documents/elements/caps.rs
@@ -8,7 +8,7 @@ use crate::{xml_builder::XMLBuilder, BuildXML};
 
 #[derive(Debug, Clone, Deserialize, PartialEq)]
 pub struct Caps {
-    val: bool,
+    pub val: bool,
 }
 
 impl Caps {

--- a/docx-core/src/documents/elements/character_spacing.rs
+++ b/docx-core/src/documents/elements/character_spacing.rs
@@ -7,7 +7,7 @@ use serde::*;
 #[derive(Debug, Clone, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct CharacterSpacing {
-    value: i32,
+    pub value: i32,
 }
 
 impl CharacterSpacing {

--- a/docx-core/src/documents/elements/color.rs
+++ b/docx-core/src/documents/elements/color.rs
@@ -6,7 +6,7 @@ use crate::xml_builder::*;
 
 #[derive(Deserialize, Debug, Clone, PartialEq)]
 pub struct Color {
-    val: String,
+    pub val: String,
 }
 
 impl Color {

--- a/docx-core/src/documents/elements/highlight.rs
+++ b/docx-core/src/documents/elements/highlight.rs
@@ -6,7 +6,7 @@ use crate::xml_builder::*;
 
 #[derive(Debug, Clone, Deserialize, PartialEq)]
 pub struct Highlight {
-    val: String,
+    pub val: String,
 }
 
 impl Highlight {

--- a/docx-core/src/documents/elements/italic.rs
+++ b/docx-core/src/documents/elements/italic.rs
@@ -6,7 +6,7 @@ use crate::xml_builder::*;
 
 #[derive(Debug, Clone, Deserialize, PartialEq)]
 pub struct Italic {
-    val: bool,
+    pub val: bool,
 }
 
 impl Italic {

--- a/docx-core/src/documents/elements/italic_cs.rs
+++ b/docx-core/src/documents/elements/italic_cs.rs
@@ -6,7 +6,7 @@ use crate::xml_builder::*;
 
 #[derive(Debug, Clone, Deserialize, PartialEq)]
 pub struct ItalicCs {
-    val: bool,
+    pub val: bool,
 }
 
 impl ItalicCs {

--- a/docx-core/src/documents/elements/line_spacing.rs
+++ b/docx-core/src/documents/elements/line_spacing.rs
@@ -9,17 +9,17 @@ use serde::*;
 #[serde(rename_all = "camelCase")]
 pub struct LineSpacing {
     #[serde(skip_serializing_if = "Option::is_none")]
-    line_rule: Option<LineSpacingType>,
+    pub line_rule: Option<LineSpacingType>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    before: Option<u32>,
+    pub before: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    after: Option<u32>,
+    pub after: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    before_lines: Option<u32>,
+    pub before_lines: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    after_lines: Option<u32>,
+    pub after_lines: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    line: Option<i32>,
+    pub line: Option<i32>,
 }
 
 impl LineSpacing {

--- a/docx-core/src/documents/elements/link.rs
+++ b/docx-core/src/documents/elements/link.rs
@@ -7,7 +7,7 @@ use crate::xml_builder::*;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Link {
-    val: String,
+    pub val: String,
 }
 
 impl Link {

--- a/docx-core/src/documents/elements/run_fonts.rs
+++ b/docx-core/src/documents/elements/run_fonts.rs
@@ -17,23 +17,23 @@ use crate::xml_builder::*;
 #[serde(rename_all = "camelCase")]
 pub struct RunFonts {
     #[serde(skip_serializing_if = "Option::is_none")]
-    ascii: Option<String>,
+    pub ascii: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    hi_ansi: Option<String>,
+    pub hi_ansi: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    east_asia: Option<String>,
+    pub east_asia: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    cs: Option<String>,
+    pub cs: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ascii_theme: Option<String>,
+    pub ascii_theme: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    hi_ansi_theme: Option<String>,
+    pub hi_ansi_theme: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    east_asia_theme: Option<String>,
+    pub east_asia_theme: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    cs_theme: Option<String>,
+    pub cs_theme: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    hint: Option<String>,
+    pub hint: Option<String>,
 }
 
 impl RunFonts {

--- a/docx-core/src/documents/elements/sz.rs
+++ b/docx-core/src/documents/elements/sz.rs
@@ -6,7 +6,7 @@ use crate::xml_builder::*;
 
 #[derive(Debug, Clone, Deserialize, PartialEq)]
 pub struct Sz {
-    val: usize,
+    pub val: usize,
 }
 
 impl Sz {

--- a/docx-core/src/documents/elements/sz_cs.rs
+++ b/docx-core/src/documents/elements/sz_cs.rs
@@ -5,7 +5,7 @@ use std::io::Write;
 
 #[derive(Deserialize, Debug, Clone, PartialEq)]
 pub struct SzCs {
-    val: usize,
+    pub val: usize,
 }
 
 impl SzCs {

--- a/docx-core/src/documents/elements/underline.rs
+++ b/docx-core/src/documents/elements/underline.rs
@@ -6,7 +6,7 @@ use crate::xml_builder::*;
 
 #[derive(Debug, Clone, Deserialize, PartialEq)]
 pub struct Underline {
-    val: String,
+    pub val: String,
 }
 
 impl Underline {

--- a/docx-core/src/documents/elements/vert_align.rs
+++ b/docx-core/src/documents/elements/vert_align.rs
@@ -7,7 +7,7 @@ use crate::xml_builder::*;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct VertAlign {
-    val: VertAlignType,
+    pub val: VertAlignType,
 }
 
 impl VertAlign {


### PR DESCRIPTION
## What does this change?

Properties defined as structs under `RunProperties` (such as `Sz`, `Bold`, `FontRun`...) have now its internal values as public.


## Benefits

- Enhances flexibility of the crate, by giving reading access to users creating or loading these fields manually 
- Help checking run properties when loading docx documents from a file
- Ease debugging 
- Validate if the system is able to retrieve that kind of properties (for example, a certain font which is not installed)
- Validate if the property even exists in some cases (Right now we could have a `Some(RunFont)` with only `None` or empty strings as attributes, and it wouldn't be possible to check it)

## References

https://github.com/bokuweb/docx-rs/issues/675

## Other considerations:

Tests, backwards compatibility and performance wouldn't be affected, since none of the logic or data structure is modified _per se_
