### PR TITLE
fix: add section_property in paragraph and pic behind_doc

### DIFF
--- a/docx-core/src/documents/elements/drawing.rs
+++ b/docx-core/src/documents/elements/drawing.rs
@@ -82,7 +82,7 @@ impl BuildXML for Drawing {
                             &format!("{}", p.dist_r),
                             "0",
                             if p.simple_pos { "1" } else { "0" },
-                            "0",
+                            if p.behind_doc { "1" } else { "0" },
                             "0",
                             if p.layout_in_cell { "1" } else { "0" },
                             &format!("{}", p.relative_height),

--- a/docx-core/src/documents/elements/paragraph_property.rs
+++ b/docx-core/src/documents/elements/paragraph_property.rs
@@ -25,8 +25,8 @@ pub struct ParagraphProperty {
     pub keep_next: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub keep_lines: Option<bool>,
-    #[serde(skip_serializing_if="Option::is_none")]
-    pub bidi:Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bidi: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub page_break_before: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -133,8 +133,8 @@ impl ParagraphProperty {
         self.page_break_before = Some(v);
         self
     }
-    pub fn bidi(mut self,v:bool)->Self{
-        self.bidi=Some(v);
+    pub fn bidi(mut self, v: bool) -> Self {
+        self.bidi = Some(v);
         self
     }
     pub fn widow_control(mut self, v: bool) -> Self {
@@ -220,6 +220,7 @@ impl BuildXML for ParagraphProperty {
         XMLBuilder::from(stream)
             .open_paragraph_property()?
             .add_child(&self.run_property)?
+            .add_optional_child(&self.section_property)?
             .add_optional_child(&self.style)?
             .add_optional_child(&self.numbering_property)?
             .add_optional_child(&self.frame_property)?
@@ -235,7 +236,7 @@ impl BuildXML for ParagraphProperty {
             .apply_if(self.keep_next, |b| b.keep_next())?
             .apply_if(self.keep_lines, |b| b.keep_lines())?
             .apply_if(self.page_break_before, |b| b.page_break_before())?
-            .apply_if(self.bidi,|b| b.bidi())?
+            .apply_if(self.bidi, |b| b.bidi())?
             .apply_opt(self.widow_control, |flag, b| {
                 b.widow_control(if flag { "1" } else { "0" })
             })?
@@ -265,11 +266,14 @@ mod tests {
     }
 
     #[test]
-    fn test_bidi(){
-        let c=ParagraphProperty::new().bidi(true);
-        let b=c.build();
+    fn test_bidi() {
+        let c = ParagraphProperty::new().bidi(true);
+        let b = c.build();
         println!("-----Test bidi: {}", str::from_utf8(&b).unwrap());
-        assert_eq!(str::from_utf8(&b).unwrap(),r#"<w:pPr><w:rPr /><w:bidi /></w:pPr>"#);
+        assert_eq!(
+            str::from_utf8(&b).unwrap(),
+            r#"<w:pPr><w:rPr /><w:bidi /></w:pPr>"#
+        );
     }
     #[test]
     fn test_alignment() {

--- a/docx-core/src/documents/elements/pic.rs
+++ b/docx-core/src/documents/elements/pic.rs
@@ -25,6 +25,8 @@ pub struct Pic {
     // unit is emu
     pub simple_pos_x: i32,
     pub simple_pos_y: i32,
+    /// Specifies whether this DrawingML object (e.g., an image) is displayed behind the document text.
+    pub behind_doc: bool,
     /// Specifies how this DrawingML object behaves when its anchor is located in a table cell;
     /// and its specified position would cause it to intersect with a table cell displayed in the
     /// document. That behavior shall be as follows:
@@ -76,6 +78,7 @@ impl Pic {
             simple_pos: false,
             simple_pos_x: 0,
             simple_pos_y: 0,
+            behind_doc: false,
             layout_in_cell: false,
             relative_height: 190500,
             allow_overlap: false,
@@ -100,6 +103,7 @@ impl Pic {
             simple_pos: false,
             simple_pos_x: 0,
             simple_pos_y: 0,
+            behind_doc: false,
             layout_in_cell: false,
             relative_height: 190500,
             allow_overlap: false,
@@ -134,6 +138,11 @@ impl Pic {
 
     pub fn floating(mut self) -> Pic {
         self.position_type = DrawingPositionType::Anchor;
+        self
+    }
+
+    pub fn behind(mut self) -> Pic {
+        self.behind_doc = true;
         self
     }
 


### PR DESCRIPTION
1. Section Property Building within Paragraphs: Adds support for building SectionProperty directly within a Paragraph. This is crucial for defining and managing document sections dynamically, particularly for advanced page numbering scenarios (e.g., starting page numbers from a specific point, or having different page number formats for different parts of the document). Previously, SectionProperty could only be applied at the document level, limiting granular control.

2. behind_doc Support for Images: Introduces the behind_doc attribute for Drawing objects (specifically for Anchor-positioned images). Setting this to true allows images to be placed "behind text" within the document. This enables effects like watermarks, background images, or other overlaid visual elements, providing greater flexibility in document design.