### PR TITLE
add support ：AbstractNumbering  <w:multiLevelType w:val="multilevel"/>

### DIFF
--- a/docx-core/src/documents/elements/abstract_numbering.rs
+++ b/docx-core/src/documents/elements/abstract_numbering.rs
@@ -11,6 +11,7 @@ pub struct AbstractNumbering {
     pub style_link: Option<String>,
     pub num_style_link: Option<String>,
     pub levels: Vec<Level>,
+     pub multi_level_type: Option<String>,
 }
 
 impl AbstractNumbering {
@@ -20,6 +21,7 @@ impl AbstractNumbering {
             style_link: None,
             num_style_link: None,
             levels: vec![],
+            multi_level_type: None,
         }
     }
 
@@ -44,11 +46,18 @@ impl BuildXML for AbstractNumbering {
         &self,
         stream: xml::writer::EventWriter<W>,
     ) -> xml::writer::Result<xml::writer::EventWriter<W>> {
-        XMLBuilder::from(stream)
-            .open_abstract_num(&self.id.to_string())?
-            .add_children(&self.levels)?
-            .close()?
-            .into_inner()
+        let mut builder = XMLBuilder::from(stream)  
+            .open_abstract_num(&self.id.to_string())?;  
+          
+        // 添加 multiLevelType 元素（如果存在）  
+        if let Some(ref multi_level_type) = self.multi_level_type {  
+            builder = builder.multi_level_type(multi_level_type)?;  
+        }  
+          
+        builder  
+            .add_children(&self.levels)?  
+            .close()?  
+            .into_inner()  
     }
 }
 

--- a/docx-core/src/documents/elements/abstract_numbering.rs
+++ b/docx-core/src/documents/elements/abstract_numbering.rs
@@ -11,7 +11,8 @@ pub struct AbstractNumbering {
     pub style_link: Option<String>,
     pub num_style_link: Option<String>,
     pub levels: Vec<Level>,
-     pub multi_level_type: Option<String>,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub multi_level_type: Option<String>,
 }
 
 impl AbstractNumbering {

--- a/docx-core/src/xml_builder/elements.rs
+++ b/docx-core/src/xml_builder/elements.rs
@@ -446,6 +446,8 @@ impl<W: Write> XMLBuilder<W> {
         "w:initials"
     );
 
+    closed_with_str!(multi_level_type, "w:multiLevelType");
+
     open!(open_abstract_num, "w:abstractNum", "w:abstractNumId");
     open!(open_level, "w:lvl", "w:ilvl");
     open!(open_tabs, "w:tabs");


### PR DESCRIPTION
## What does this change?

Add support for multiLevelType element in AbstractNumbering structure. This enhancement allows users to specify the multi-level type attribute for abstract numbering definitions in DOCX documents, providing better control over numbering list hierarchies and improving compatibility with Microsoft Word's numbering features.

## References

- Added [multi_level_type] field as Option<String> to the AbstractNumbering struct

## Screenshots

![image](https://github.com/user-attachments/assets/172b3499-ab72-464b-9289-db5112c5531d)
![image](https://github.com/user-attachments/assets/ba5754ab-fde2-46c2-9834-55657b38dfb5)



