### PR TITLE
Make Paragraph.raw_text() include tabs and newlines

### DIFF
--- a/docx-core/src/documents/elements/paragraph.rs
+++ b/docx-core/src/documents/elements/paragraph.rs
@@ -374,8 +374,20 @@ impl Paragraph {
                     for c in i.children.iter() {
                         if let InsertChild::Run(r) = c {
                             for c in r.children.iter() {
-                                if let RunChild::Text(t) = c {
-                                    s.push_str(&t.text);
+                                match c {
+                                    RunChild::Text(t) => {
+                                        s.push_str(&t.text);
+                                    }
+                                    RunChild::Tab(_t) => {
+                                        s.push_str("\t");
+                                    }
+                                    RunChild::PTab(_t) => {
+                                        s.push_str("\t");
+                                    }
+                                    RunChild::Break(_b) => {
+                                        s.push_str("\n");
+                                    }
+                                    _ => {}
                                 }
                             }
                         }
@@ -383,8 +395,20 @@ impl Paragraph {
                 }
                 ParagraphChild::Run(run) => {
                     for c in run.children.iter() {
-                        if let RunChild::Text(t) = c {
-                            s.push_str(&t.text);
+                        match c {
+                            RunChild::Text(t) => {
+                                s.push_str(&t.text);
+                            }
+                            RunChild::Tab(_t) => {
+                                s.push_str("\t");
+                            }
+                            RunChild::PTab(_t) => {
+                                s.push_str("\t");
+                            }
+                            RunChild::Break(_b) => {
+                                s.push_str("\n");
+                            }
+                            _ => {}
                         }
                     }
                 }


### PR DESCRIPTION
## What does this change?

This change makes `Paragraph.raw_text()` include tabs and newlines. The current implementation only takes `Text` in `RunChild` into account. If tabs and newlines are not handled, a raw text may have missing whitespaces and may cause incorrect further handling, e.g. regular expression match failure.
