### PR TITLE
Reflect RunChild::CarriageReturn to Paragraph.raw_text()

### DIFF
--- a/docx-core/src/documents/elements/paragraph.rs
+++ b/docx-core/src/documents/elements/paragraph.rs
@@ -414,6 +414,9 @@ impl Paragraph {
                                     RunChild::Break(_b) => {
                                         s.push_str("\n");
                                     }
+                                    RunChild::CarriageReturn(_cr) => {
+                                        s.push_str("\n");
+                                    }
                                     _ => {}
                                 }
                             }
@@ -433,6 +436,9 @@ impl Paragraph {
                                 s.push_str("\t");
                             }
                             RunChild::Break(_b) => {
+                                s.push_str("\n");
+                            }
+                            RunChild::CarriageReturn(_cr) => {
                                 s.push_str("\n");
                             }
                             _ => {}


### PR DESCRIPTION
## What does this change?

This is a follow-up of #886 and #887. So CarriageReturn is introduced in `RunChild`, I guess it would be better if `Paragraph.raw_text()` takes this into account.
