### PR TITLE
Release 0.4.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `RunProperty`, `Run`, and `Style`. Emits `w:themeColor` / `w:themeShade`
   / `w:themeTint` (with the `w:val` hex kept as a fallback) and reads them
   back, so generated documents adapt when the Word theme changes.
-- Add optional `emf` feature: convert embedded EMF images to SVG on read
-  via the [`emf-core`](https://github.com/mythrnr/emf-rs) crate. EMF
-  entries are surfaced through the existing `Docx.images` field; the
-  preview slot holds SVG bytes (instead of PNG) for paths ending in
-  `.emf`. docx-wasm enables this feature by default.
+- Convert embedded EMF images to SVG in docx-wasm via the
+  [`emf-core`](https://github.com/mythrnr/emf-rs) crate. EMF entries are
+  surfaced through the existing `Docx.images` field; the original bytes
+  are preserved and docx-wasm fills the preview slot with SVG instead of
+  PNG. The published `docx-rs` crate does not depend on the unpublished
+  EMF conversion crates.
 - Added `Style::shading` and `Paragraph::set_borders` delegating builders (fork).
 
 ## @0.4.20 (2. Apr, 2026)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,22 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## @0.4.20 (x. XXX, 2026)
+
+## @0.4.21 (20. Jul, 2026)
 
 - Support theme colors on `<w:color>`: new `ThemeColor` enum and
   `theme_color` / `theme_shade` / `theme_tint` builders on `Color`,
   `RunProperty`, `Run`, and `Style`. Emits `w:themeColor` / `w:themeShade`
   / `w:themeTint` (with the `w:val` hex kept as a fallback) and reads them
   back, so generated documents adapt when the Word theme changes.
-- Support `fitText`
-- Support `qFormat` / `uiPriority` / `semiHidden` / `unhideWhenUsed`
-- Support `off`
 - Add optional `emf` feature: convert embedded EMF images to SVG on read
   via the [`emf-core`](https://github.com/mythrnr/emf-rs) crate. EMF
   entries are surfaced through the existing `Docx.images` field; the
   preview slot holds SVG bytes (instead of PNG) for paths ending in
   `.emf`. docx-wasm enables this feature by default.
 - Added `Style::shading` and `Paragraph::set_borders` delegating builders (fork).
+
+## @0.4.20 (2. Apr, 2026)
+
+- Support `fitText`
+- Support `qFormat` / `uiPriority` / `semiHidden` / `unhideWhenUsed`
+- Support `off`
 
 ## @0.4.19 (8. Feb, 2026)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,7 +244,6 @@ version = "0.4.21"
 dependencies = [
  "base64",
  "criterion",
- "emf-core",
  "image",
  "insta",
  "pretty_assertions",
@@ -254,7 +253,6 @@ dependencies = [
  "thiserror",
  "ts-rs",
  "wasm-bindgen",
- "wmf-core",
  "zip",
 ]
 
@@ -264,7 +262,9 @@ version = "0.1.0"
 dependencies = [
  "console_error_panic_hook",
  "docx-rs",
+ "emf-core",
  "wasm-bindgen",
+ "wmf-core",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,7 +240,7 @@ checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "docx-rs"
-version = "0.4.20"
+version = "0.4.21"
 dependencies = [
  "base64",
  "criterion",

--- a/docx-core/Cargo.toml
+++ b/docx-core/Cargo.toml
@@ -35,10 +35,10 @@ image = { version = "0.25", default-features = false, features = [
     "bmp",
     "tiff",
 ], optional = true }
-emf-core = { git = "https://github.com/mythrnr/emf-rs.git", tag = "0.0.7", default-features = false, features = [
+emf-core = { version = "0.1.0", git = "https://github.com/mythrnr/emf-rs.git", tag = "0.0.7", default-features = false, features = [
     "svg",
 ], optional = true }
-wmf-core = { git = "https://github.com/mythrnr/wmf-rs.git", tag = "0.0.23", default-features = false, features = [
+wmf-core = { version = "0.1.0", git = "https://github.com/mythrnr/wmf-rs.git", tag = "0.0.23", default-features = false, features = [
     "svg",
 ], optional = true }
 wasm-bindgen = { version = "0.2", optional = true }

--- a/docx-core/Cargo.toml
+++ b/docx-core/Cargo.toml
@@ -16,9 +16,6 @@ path = "src/lib.rs"
 [features]
 default = ["image"]
 wasm = ["wasm-bindgen", "ts-rs", "image"]
-# Convert EMF (Enhanced Metafile) images embedded in a docx to SVG on read,
-# via the `emf-core` crate from https://github.com/mythrnr/emf-rs.
-emf = ["emf-core", "wmf-core"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -34,12 +31,6 @@ image = { version = "0.25", default-features = false, features = [
     "png",
     "bmp",
     "tiff",
-], optional = true }
-emf-core = { version = "0.1.0", git = "https://github.com/mythrnr/emf-rs.git", tag = "0.0.7", default-features = false, features = [
-    "svg",
-], optional = true }
-wmf-core = { version = "0.1.0", git = "https://github.com/mythrnr/wmf-rs.git", tag = "0.0.23", default-features = false, features = [
-    "svg",
 ], optional = true }
 wasm-bindgen = { version = "0.2", optional = true }
 ts-rs = { version = "12.0", optional = true }

--- a/docx-core/Cargo.toml
+++ b/docx-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "docx-rs"
-version = "0.4.20"
+version = "0.4.21"
 authors = ["bokuweb <bokuweb12@gmail.com>"]
 repository = "https://github.com/bokuweb/docx-rs"
 edition = "2021"

--- a/docx-core/src/documents/mod.rs
+++ b/docx-core/src/documents/mod.rs
@@ -92,18 +92,16 @@ pub struct Image(pub Vec<u8>);
 /// Decoded preview bytes for an entry in `Docx.images`.
 ///
 /// For raster originals (PNG / JPEG / BMP / GIF / TIFF) decoded via the
-/// `image` crate, the contents are PNG bytes. For EMF originals decoded
-/// via the `emf` feature, the contents are SVG bytes instead. The struct
-/// is named `Png` for backwards compatibility; callers can distinguish
-/// the two cases by sniffing the bytes (`<svg` / `\x89PNG`) or by
-/// checking the corresponding path's file extension (`.emf` → SVG).
+/// `image` crate, the contents are PNG bytes. Unsupported formats such as
+/// EMF are surfaced with an empty preview so downstream consumers can
+/// provide their own conversion. The struct is named `Png` for backwards
+/// compatibility.
 #[derive(Debug, Clone)]
 pub struct Png(pub Vec<u8>);
 
 pub type ImageIdAndPath = (String, String);
 pub type ImageIdAndBuf = (String, Vec<u8>);
 
-#[cfg(feature = "emf")]
 fn is_emf(path: &str, buf: &[u8]) -> bool {
     if path.to_ascii_lowercase().ends_with(".emf") {
         return true;
@@ -114,14 +112,6 @@ fn is_emf(path: &str, buf: &[u8]) -> bool {
     buf.len() >= 44
         && buf[0..4] == [0x01, 0x00, 0x00, 0x00]
         && buf[40..44] == [0x20, 0x45, 0x4D, 0x46]
-}
-
-#[cfg(feature = "emf")]
-fn convert_emf_to_svg(buf: &[u8]) -> Option<Vec<u8>> {
-    let wmf_player = wmf_core::converter::SVGPlayer::new();
-    let emf_player = emf_core::converter::SVGPlayer::new();
-    let converter = emf_core::converter::EMFConverter::new(buf, emf_player, wmf_player);
-    converter.run().ok()
 }
 
 impl ser::Serialize for Image {
@@ -172,8 +162,8 @@ pub struct Docx {
     ///
     /// Each tuple is `(rId, media path, original bytes, preview bytes)`.
     /// The preview is PNG for raster originals decoded via the `image`
-    /// crate, and SVG for EMF originals decoded via the `emf` feature.
-    /// See [`Png`] for details.
+    /// crate. Unsupported formats such as EMF keep an empty preview for
+    /// downstream consumers to populate. See [`Png`] for details.
     pub images: Vec<(String, String, Image, Png)>,
     // reader only
     pub hyperlinks: Vec<(String, String, String)>,
@@ -283,17 +273,10 @@ impl Docx {
     ) -> Self {
         let path: String = path.into();
 
-        #[cfg(feature = "emf")]
         if is_emf(&path, &buf) {
-            if let Some(svg) = convert_emf_to_svg(&buf) {
-                // The `Png` slot holds SVG bytes here — see the doc
-                // comment on `Png`. Consumers can detect this case via
-                // the `.emf` extension on the path.
-                self.images.push((id.into(), path, Image(buf), Png(svg)));
-                return self;
-            }
-            // Conversion failed — fall through so the original bytes
-            // are still surfaced via the regular path (best-effort).
+            self.images
+                .push((id.into(), path, Image(buf), Png(Vec::new())));
+            return self;
         }
 
         #[cfg(feature = "image")]
@@ -2465,13 +2448,12 @@ fn update_document_by_toc(
     children
 }
 
-#[cfg(all(test, feature = "emf"))]
+#[cfg(test)]
 mod emf_tests {
     use super::*;
 
     /// Build a syntactically-valid, minimal EMF: an EMR_HEADER followed by
-    /// an EMR_EOF. emf-core should accept this and emit a (possibly empty)
-    /// SVG document.
+    /// an EMR_EOF.
     pub(super) fn minimal_valid_emf() -> Vec<u8> {
         let mut buf = Vec::<u8>::with_capacity(108);
 
@@ -2581,34 +2563,10 @@ mod emf_tests {
         assert!(!is_emf("x.bin", &buf));
     }
 
-    // ---------- convert_emf_to_svg ----------
-
-    #[test]
-    fn convert_emf_to_svg_produces_svg_for_valid_input() {
-        let bytes = convert_emf_to_svg(&minimal_valid_emf()).expect("conversion should succeed");
-        assert!(!bytes.is_empty(), "SVG output should not be empty");
-        let text = std::str::from_utf8(&bytes).expect("SVG output should be UTF-8");
-        // The emf-core SVG player emits an <svg ...> element. Don't pin
-        // down the exact prologue — just look for the opening tag.
-        assert!(
-            text.contains("<svg"),
-            "SVG output should contain `<svg`, got: {}",
-            &text[..text.len().min(200)]
-        );
-    }
-
-    #[test]
-    fn convert_emf_to_svg_handles_corrupt_input_without_panicking() {
-        // Either Some(_) or None is fine — we only care that it doesn't
-        // panic on bytes that pass our cheap signature sniff but aren't
-        // a real EMF stream.
-        let _ = convert_emf_to_svg(&corrupt_emf_header());
-    }
-
     // ---------- add_image routing ----------
 
     #[test]
-    fn add_image_routes_valid_emf_into_images_with_svg_preview() {
+    fn add_image_routes_valid_emf_into_images_with_empty_preview() {
         let buf = minimal_valid_emf();
         let docx = Docx::new().add_image("rId1", "word/media/image1.emf", buf.clone());
 
@@ -2621,25 +2579,17 @@ mod emf_tests {
         assert_eq!(id, "rId1");
         assert_eq!(path, "word/media/image1.emf");
         assert_eq!(original.0, buf);
-        // For .emf entries the `Png` slot actually holds SVG bytes.
-        assert!(!preview.0.is_empty());
-        assert!(std::str::from_utf8(&preview.0).unwrap().contains("<svg"));
+        assert!(preview.0.is_empty());
     }
 
     #[test]
-    fn add_image_falls_through_on_emf_conversion_failure() {
-        // The corrupt header passes `is_emf` (correct signature) but
-        // can't be parsed end-to-end. The reader should fall through to
-        // the image-crate path rather than storing an empty SVG. The
-        // `image` crate will then also fail on these bytes, so nothing
-        // ends up in `images` — same behaviour as today for any
-        // unrecognised media file.
+    fn add_image_preserves_emf_detected_by_magic_bytes() {
         let buf = corrupt_emf_header();
-        let docx = Docx::new().add_image("rId1", "word/media/image1.bin", buf);
-        assert!(
-            docx.images.is_empty(),
-            "failed EMF conversion + failed PNG decode = no entry"
-        );
+        let docx = Docx::new().add_image("rId1", "word/media/image1.bin", buf.clone());
+        assert_eq!(docx.images.len(), 1);
+        let (_, _, original, preview) = &docx.images[0];
+        assert_eq!(original.0, buf);
+        assert!(preview.0.is_empty());
     }
 
     #[test]
@@ -2681,11 +2631,10 @@ mod emf_tests {
     }
 }
 
-/// Reader-level integration tests for the `emf` feature. We construct a
-/// tiny in-memory docx (just enough relationships + a media entry) and
-/// run it through `read_docx` to verify the converted SVG surfaces on
-/// `Docx.images` (the EMF case stores SVG bytes in the preview slot).
-#[cfg(all(test, feature = "emf"))]
+/// Reader-level integration tests for EMF passthrough. We construct a tiny
+/// in-memory docx (just enough relationships + a media entry) and run it
+/// through `read_docx` to verify the original bytes surface on `Docx.images`.
+#[cfg(test)]
 mod emf_reader_tests {
     use super::emf_tests::minimal_valid_emf;
     use std::io::Write;
@@ -2738,7 +2687,7 @@ mod emf_reader_tests {
     }
 
     #[test]
-    fn read_docx_routes_emf_media_to_images_with_svg_preview() {
+    fn read_docx_routes_emf_media_to_images_with_empty_preview() {
         let docx_bytes = build_docx_with_emf();
         let docx = crate::reader::read_docx(&docx_bytes).expect("should read docx");
 
@@ -2751,8 +2700,6 @@ mod emf_reader_tests {
         assert_eq!(id, "rId10");
         assert!(path.ends_with("image1.emf"));
         assert_eq!(original.0, minimal_valid_emf());
-        // For .emf entries the preview slot holds SVG bytes (not PNG).
-        let preview_text = std::str::from_utf8(&preview.0).expect("SVG should be UTF-8");
-        assert!(preview_text.contains("<svg"));
+        assert!(preview.0.is_empty());
     }
 }

--- a/docx-wasm/Cargo.toml
+++ b/docx-wasm/Cargo.toml
@@ -13,4 +13,10 @@ crate-type = ["cdylib"]
 [dependencies]
 wasm-bindgen = "0.2"
 console_error_panic_hook = "0.1.7"
-docx-rs = { path = "../docx-core", features = ["wasm", "emf"] }
+docx-rs = { path = "../docx-core", features = ["wasm"] }
+emf-core = { git = "https://github.com/mythrnr/emf-rs.git", tag = "0.0.7", default-features = false, features = [
+    "svg",
+] }
+wmf-core = { git = "https://github.com/mythrnr/wmf-rs.git", tag = "0.0.23", default-features = false, features = [
+    "svg",
+] }

--- a/docx-wasm/package.json
+++ b/docx-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docx-wasm",
-  "version": "0.4.20",
+  "version": "0.4.21",
   "main": "dist/node/index.js",
   "browser": "dist/web/index.js",
   "author": "bokuweb <bokuweb12@gmail.com>",

--- a/docx-wasm/src/reader.rs
+++ b/docx-wasm/src/reader.rs
@@ -1,11 +1,41 @@
 use wasm_bindgen::prelude::*;
 
+fn is_emf(path: &str, buf: &[u8]) -> bool {
+    if path.to_ascii_lowercase().ends_with(".emf") {
+        return true;
+    }
+
+    buf.len() >= 44
+        && buf[0..4] == [0x01, 0x00, 0x00, 0x00]
+        && buf[40..44] == [0x20, 0x45, 0x4D, 0x46]
+}
+
+fn convert_emf_to_svg(buf: &[u8]) -> Option<Vec<u8>> {
+    let wmf_player = wmf_core::converter::SVGPlayer::new();
+    let emf_player = emf_core::converter::SVGPlayer::new();
+    let converter = emf_core::converter::EMFConverter::new(buf, emf_player, wmf_player);
+    converter.run().ok()
+}
+
+fn add_emf_previews(docx: &mut docx_rs::Docx) {
+    for (_, path, original, preview) in &mut docx.images {
+        if is_emf(path, &original.0) {
+            if let Some(svg) = convert_emf_to_svg(&original.0) {
+                preview.0 = svg;
+            }
+        }
+    }
+}
+
 #[allow(non_snake_case)]
 #[wasm_bindgen]
 pub fn readDocx(buf: &[u8]) -> Result<String, JsValue> {
     let mut d = docx_rs::read_docx(buf);
     match d {
-        Ok(ref mut d) => Ok(d.json()),
+        Ok(ref mut d) => {
+            add_emf_previews(d);
+            Ok(d.json())
+        }
         Err(e) => Err(e.to_string().into()),
     }
 }


### PR DESCRIPTION
## Summary

- Prepare the Rust crate and WASM package for the 0.4.21 release.
- Add theme color support and the new shading and paragraph border builders.
- Keep EMF-to-SVG conversion enabled in `docx-wasm` while removing the unpublished EMF git dependencies from the crates.io-published `docx-rs` crate.
- Preserve EMF originals in `Docx.images`; `docx-wasm` fills their preview slot with converted SVG bytes.

## Why

crates.io does not publish git dependency locations. Keeping `emf-core` and `wmf-core` in `docx-core` prevented `docx-rs` from being packaged because those crates are not available from crates.io.

## Impact

`docx-rs` 0.4.21 can be packaged for crates.io without the unpublished conversion crates, while npm consumers of `docx-wasm` retain EMF-to-SVG previews.

## Validation

- `cargo package -p docx-rs --allow-dirty`
- `cargo test -p docx-rs documents::emf` — 12 passed
- `cargo build -p docx-wasm --target wasm32-unknown-unknown`
- `pnpm wasm-pack:node`
- `pnpm wasm-pack:dev`
- `pnpm exec tsc -p tsconfig.node.json`
- `pnpm jest --runInBand` — 92 passed, including the embedded EMF conversion test
