### PR TITLE
Improve DOCX read and write performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,6 +243,7 @@ name = "docx-rs"
 version = "0.4.21"
 dependencies = [
  "base64",
+ "crc32fast",
  "criterion",
  "image",
  "insta",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,6 +250,7 @@ dependencies = [
  "quick-xml",
  "serde",
  "serde_json",
+ "smallvec",
  "thiserror",
  "ts-rs",
  "wasm-bindgen",
@@ -719,6 +720,12 @@ name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "snafu"

--- a/docx-core/Cargo.toml
+++ b/docx-core/Cargo.toml
@@ -26,6 +26,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
 smallvec = "1.15"
 base64 = "0.22.1"
+crc32fast = "1.5"
 image = { version = "0.25", default-features = false, features = [
     "gif",
     "jpeg",

--- a/docx-core/Cargo.toml
+++ b/docx-core/Cargo.toml
@@ -24,6 +24,7 @@ thiserror = "2.0"
 zip = { version = "8.6.0", default-features = false, features = ["deflate"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
+smallvec = "1.15"
 base64 = "0.22.1"
 image = { version = "0.25", default-features = false, features = [
     "gif",

--- a/docx-core/benches/read_docx.rs
+++ b/docx-core/benches/read_docx.rs
@@ -1,13 +1,39 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use docx_rs::read_docx;
+use docx_rs::{read_docx, read_docx_with_options, ReadDocxOptions};
 use std::hint::black_box;
 
 fn bench_read_docx(c: &mut Criterion) {
     static DOCX_BYTES: &[u8] = include_bytes!("../../fixtures/hello_world/hello_world.docx");
+    static PNG_DOCX_BYTES: &[u8] = include_bytes!("../../fixtures/image/image.docx");
+    static JPEG_DOCX_BYTES: &[u8] = include_bytes!("../../fixtures/image_output/image.docx");
     c.bench_function("read_docx_hello", |b| {
         b.iter(|| {
             let buffer = black_box(DOCX_BYTES);
             black_box(read_docx(buffer).expect("failed to read docx"));
+        });
+    });
+    c.bench_function("read_docx_png", |b| {
+        b.iter(|| {
+            let buffer = black_box(PNG_DOCX_BYTES);
+            black_box(read_docx(buffer).expect("failed to read PNG docx"));
+        });
+    });
+    c.bench_function("read_docx_jpeg", |b| {
+        b.iter(|| {
+            let buffer = black_box(JPEG_DOCX_BYTES);
+            black_box(read_docx(buffer).expect("failed to read JPEG docx"));
+        });
+    });
+    c.bench_function("read_docx_jpeg_without_previews", |b| {
+        b.iter(|| {
+            let buffer = black_box(JPEG_DOCX_BYTES);
+            black_box(
+                read_docx_with_options(
+                    buffer,
+                    ReadDocxOptions::default().with_image_previews(false),
+                )
+                .expect("failed to read JPEG docx"),
+            );
         });
     });
 }

--- a/docx-core/benches/write_docx.rs
+++ b/docx-core/benches/write_docx.rs
@@ -19,6 +19,26 @@ fn create_template(paragraph_count: usize, runs_per_paragraph: usize) -> Docx {
 
 fn bench_write_docx(c: &mut Criterion) {
     let template = create_template(200, 5);
+    c.bench_function("write_docx_build", |b| {
+        b.iter_batched(
+            || template.clone(),
+            |docx| black_box(docx.build()),
+            BatchSize::SmallInput,
+        );
+    });
+
+    c.bench_function("write_docx_pack", |b| {
+        b.iter_batched(
+            || template.clone().build(),
+            |xml| {
+                let mut cursor = Cursor::new(Vec::with_capacity(64 * 1024));
+                xml.pack(&mut cursor).expect("failed to write docx");
+                black_box(cursor.into_inner());
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
     c.bench_function("write_docx_build_pack", |b| {
         b.iter_batched(
             || template.clone(),
@@ -30,6 +50,46 @@ fn bench_write_docx(c: &mut Criterion) {
                 black_box(cursor.into_inner());
             },
             BatchSize::SmallInput,
+        );
+    });
+
+    let large_template = create_template(2_000, 5);
+    c.bench_function("write_docx_large_build_pack", |b| {
+        b.iter_batched(
+            || large_template.clone(),
+            |docx| {
+                let mut cursor = Cursor::new(Vec::with_capacity(512 * 1024));
+                docx.build()
+                    .pack(&mut cursor)
+                    .expect("failed to write large docx");
+                black_box(cursor.into_inner());
+            },
+            BatchSize::LargeInput,
+        );
+    });
+
+    let image = vec![42; 64 * 1024];
+    let mut repeated_image_template = Docx::new();
+    for _ in 0..100 {
+        repeated_image_template = repeated_image_template.add_paragraph(
+            Paragraph::new().add_run(Run::new().add_image(Pic::new_with_dimensions(
+                image.clone(),
+                1,
+                1,
+            ))),
+        );
+    }
+    c.bench_function("write_docx_repeated_images", |b| {
+        b.iter_batched(
+            || repeated_image_template.clone(),
+            |docx| {
+                let mut cursor = Cursor::new(Vec::with_capacity(128 * 1024));
+                docx.build()
+                    .pack(&mut cursor)
+                    .expect("failed to write image docx");
+                black_box(cursor.into_inner());
+            },
+            BatchSize::LargeInput,
         );
     });
 }

--- a/docx-core/src/documents/elements/pic.rs
+++ b/docx-core/src/documents/elements/pic.rs
@@ -55,6 +55,16 @@ impl Pic {
     ///
     /// Converts the passed image to PNG internally and computes its size.
     pub fn new(buf: &[u8]) -> Pic {
+        if buf.starts_with(&[137, 80, 78, 71, 13, 10, 26, 10]) {
+            let reader = ::image::ImageReader::new(std::io::Cursor::new(buf))
+                .with_guessed_format()
+                .expect("Should detect PNG format.");
+            let (w, h) = reader
+                .into_dimensions()
+                .expect("Should read PNG dimensions.");
+            return Self::new_with_dimensions(buf.to_vec(), w, h);
+        }
+
         let img = ::image::load_from_memory(buf).expect("Should load image from memory.");
         let (w, h) = ::image::GenericImageView::dimensions(&img);
         let mut buf = std::io::Cursor::new(vec![]);

--- a/docx-core/src/documents/image_collector.rs
+++ b/docx-core/src/documents/image_collector.rs
@@ -1,37 +1,69 @@
 use crate::{
-    DeleteChild, DrawingData, InsertChild, Paragraph, ParagraphChild, RunChild,
+    DeleteChild, DrawingData, InsertChild, Paragraph, ParagraphChild, Pic, RunChild,
     StructuredDataTagChild, Table, TableCellContent, TableChild, TableRowChild, TocContent,
 };
+use std::collections::HashMap;
+use std::hash::{DefaultHasher, Hash, Hasher};
+
+#[derive(Default)]
+pub(crate) struct ImageDeduplicator {
+    by_id: HashMap<String, usize>,
+    by_hash: HashMap<u64, Vec<usize>>,
+}
+
+fn collect_pic(
+    pic: &mut Pic,
+    images: &mut Vec<(String, String)>,
+    image_bufs: &mut Vec<(String, Vec<u8>)>,
+    id_prefix: Option<&str>,
+    deduplicator: &mut ImageDeduplicator,
+) {
+    let image = std::mem::take(&mut pic.image);
+
+    if let Some(index) = deduplicator.by_id.get(&pic.id).copied() {
+        pic.id = image_bufs[index].0.clone();
+        return;
+    }
+
+    let mut hasher = DefaultHasher::new();
+    image.hash(&mut hasher);
+    let hash = hasher.finish();
+    if let Some(index) = deduplicator.by_hash.get(&hash).and_then(|candidates| {
+        candidates
+            .iter()
+            .copied()
+            .find(|index| image_bufs[*index].1 == image)
+    }) {
+        pic.id = image_bufs[index].0.clone();
+        return;
+    }
+
+    let pic_id = if let Some(prefix) = id_prefix {
+        format!("{prefix}{}", pic.id)
+    } else {
+        pic.id.clone()
+    };
+    images.push((pic_id.clone(), format!("media/{pic_id}.png")));
+    let index = image_bufs.len();
+    image_bufs.push((pic_id.clone(), image));
+    deduplicator.by_id.insert(pic_id.clone(), index);
+    deduplicator.by_hash.entry(hash).or_default().push(index);
+    pic.id = pic_id;
+}
 
 pub(crate) fn collect_images_from_paragraph(
     paragraph: &mut Paragraph,
     images: &mut Vec<(String, String)>,
     image_bufs: &mut Vec<(String, Vec<u8>)>,
     id_prefix: Option<&str>,
+    deduplicator: &mut ImageDeduplicator,
 ) {
     for child in &mut paragraph.children {
         if let ParagraphChild::Run(run) = child {
             for child in &mut run.children {
                 if let RunChild::Drawing(d) = child {
                     if let Some(DrawingData::Pic(pic)) = &mut d.data {
-                        let b = std::mem::take(&mut pic.image);
-                        let buf = image_bufs.iter().find(|x| x.0 == pic.id || x.1 == b);
-                        let pic_id = if let Some(prefix) = id_prefix {
-                            format!("{}{}", prefix, pic.id)
-                        } else {
-                            pic.id.clone()
-                        };
-                        if buf.as_ref().is_none() {
-                            images.push((
-                                pic_id.clone(),
-                                // For now only png supported
-                                format!("media/{pic_id}.png"),
-                            ));
-                            image_bufs.push((pic_id.clone(), b));
-                            pic.id = pic_id;
-                        } else {
-                            pic.id = buf.unwrap().0.clone();
-                        }
+                        collect_pic(pic, images, image_bufs, id_prefix, deduplicator);
                     }
                 }
             }
@@ -42,13 +74,7 @@ pub(crate) fn collect_images_from_paragraph(
                         for child in &mut run.children {
                             if let RunChild::Drawing(d) = child {
                                 if let Some(DrawingData::Pic(pic)) = &mut d.data {
-                                    images.push((
-                                        pic.id.clone(),
-                                        // For now only png supported
-                                        format!("media/{}.png", pic.id),
-                                    ));
-                                    let b = std::mem::take(&mut pic.image);
-                                    image_bufs.push((pic.id.clone(), b));
+                                    collect_pic(pic, images, image_bufs, id_prefix, deduplicator);
                                 }
                             }
                         }
@@ -59,13 +85,13 @@ pub(crate) fn collect_images_from_paragraph(
                                 for child in &mut run.children {
                                     if let RunChild::Drawing(d) = child {
                                         if let Some(DrawingData::Pic(pic)) = &mut d.data {
-                                            images.push((
-                                                pic.id.clone(),
-                                                // For now only png supported
-                                                format!("media/{}.png", pic.id),
-                                            ));
-                                            let b = std::mem::take(&mut pic.image);
-                                            image_bufs.push((pic.id.clone(), b));
+                                            collect_pic(
+                                                pic,
+                                                images,
+                                                image_bufs,
+                                                id_prefix,
+                                                deduplicator,
+                                            );
                                         }
                                     }
                                 }
@@ -81,13 +107,7 @@ pub(crate) fn collect_images_from_paragraph(
                     for child in &mut run.children {
                         if let RunChild::Drawing(d) = child {
                             if let Some(DrawingData::Pic(pic)) = &mut d.data {
-                                images.push((
-                                    pic.id.clone(),
-                                    // For now only png supported
-                                    format!("media/{}.png", pic.id),
-                                ));
-                                let b = std::mem::take(&mut pic.image);
-                                image_bufs.push((pic.id.clone(), b));
+                                collect_pic(pic, images, image_bufs, id_prefix, deduplicator);
                             }
                         }
                     }
@@ -102,26 +122,47 @@ pub(crate) fn collect_images_from_table(
     images: &mut Vec<(String, String)>,
     image_bufs: &mut Vec<(String, Vec<u8>)>,
     id_prefix: Option<&str>,
+    deduplicator: &mut ImageDeduplicator,
 ) {
     for TableChild::TableRow(row) in &mut table.rows {
         for TableRowChild::TableCell(cell) in &mut row.cells {
             for content in &mut cell.children {
                 match content {
                     TableCellContent::Paragraph(paragraph) => {
-                        collect_images_from_paragraph(paragraph, images, image_bufs, id_prefix);
+                        collect_images_from_paragraph(
+                            paragraph,
+                            images,
+                            image_bufs,
+                            id_prefix,
+                            deduplicator,
+                        );
                     }
-                    TableCellContent::Table(table) => {
-                        collect_images_from_table(table, images, image_bufs, id_prefix)
-                    }
+                    TableCellContent::Table(table) => collect_images_from_table(
+                        table,
+                        images,
+                        image_bufs,
+                        id_prefix,
+                        deduplicator,
+                    ),
                     TableCellContent::StructuredDataTag(tag) => {
                         for child in &mut tag.children {
                             if let StructuredDataTagChild::Paragraph(paragraph) = child {
                                 collect_images_from_paragraph(
-                                    paragraph, images, image_bufs, id_prefix,
+                                    paragraph,
+                                    images,
+                                    image_bufs,
+                                    id_prefix,
+                                    deduplicator,
                                 );
                             }
                             if let StructuredDataTagChild::Table(table) = child {
-                                collect_images_from_table(table, images, image_bufs, id_prefix);
+                                collect_images_from_table(
+                                    table,
+                                    images,
+                                    image_bufs,
+                                    id_prefix,
+                                    deduplicator,
+                                );
                             }
                         }
                     }
@@ -129,27 +170,86 @@ pub(crate) fn collect_images_from_table(
                         for child in &mut t.before_contents {
                             if let TocContent::Paragraph(paragraph) = child {
                                 collect_images_from_paragraph(
-                                    paragraph, images, image_bufs, id_prefix,
+                                    paragraph,
+                                    images,
+                                    image_bufs,
+                                    id_prefix,
+                                    deduplicator,
                                 );
                             }
                             if let TocContent::Table(table) = child {
-                                collect_images_from_table(table, images, image_bufs, id_prefix);
+                                collect_images_from_table(
+                                    table,
+                                    images,
+                                    image_bufs,
+                                    id_prefix,
+                                    deduplicator,
+                                );
                             }
                         }
 
                         for child in &mut t.after_contents {
                             if let TocContent::Paragraph(paragraph) = child {
                                 collect_images_from_paragraph(
-                                    paragraph, images, image_bufs, id_prefix,
+                                    paragraph,
+                                    images,
+                                    image_bufs,
+                                    id_prefix,
+                                    deduplicator,
                                 );
                             }
                             if let TocContent::Table(table) = child {
-                                collect_images_from_table(table, images, image_bufs, id_prefix);
+                                collect_images_from_table(
+                                    table,
+                                    images,
+                                    image_bufs,
+                                    id_prefix,
+                                    deduplicator,
+                                );
                             }
                         }
                     }
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Run;
+
+    #[test]
+    fn deduplicates_identical_images_across_paragraphs() {
+        let image = vec![1, 2, 3, 4, 5];
+        let mut first = Paragraph::new().add_run(Run::new().add_image(Pic::new_with_dimensions(
+            image.clone(),
+            1,
+            1,
+        )));
+        let mut second =
+            Paragraph::new().add_run(Run::new().add_image(Pic::new_with_dimensions(image, 1, 1)));
+        let mut images = Vec::new();
+        let mut image_bufs = Vec::new();
+        let mut deduplicator = ImageDeduplicator::default();
+
+        collect_images_from_paragraph(
+            &mut first,
+            &mut images,
+            &mut image_bufs,
+            None,
+            &mut deduplicator,
+        );
+        collect_images_from_paragraph(
+            &mut second,
+            &mut images,
+            &mut image_bufs,
+            None,
+            &mut deduplicator,
+        );
+
+        assert_eq!(images.len(), 1);
+        assert_eq!(image_bufs.len(), 1);
     }
 }

--- a/docx-core/src/documents/image_collector.rs
+++ b/docx-core/src/documents/image_collector.rs
@@ -3,12 +3,11 @@ use crate::{
     StructuredDataTagChild, Table, TableCellContent, TableChild, TableRowChild, TocContent,
 };
 use std::collections::HashMap;
-use std::hash::{DefaultHasher, Hash, Hasher};
 
 #[derive(Default)]
 pub(crate) struct ImageDeduplicator {
     by_id: HashMap<String, usize>,
-    by_hash: HashMap<u64, Vec<usize>>,
+    by_fingerprint: HashMap<(usize, u32), Vec<usize>>,
 }
 
 fn collect_pic(
@@ -25,15 +24,17 @@ fn collect_pic(
         return;
     }
 
-    let mut hasher = DefaultHasher::new();
-    image.hash(&mut hasher);
-    let hash = hasher.finish();
-    if let Some(index) = deduplicator.by_hash.get(&hash).and_then(|candidates| {
-        candidates
-            .iter()
-            .copied()
-            .find(|index| image_bufs[*index].1 == image)
-    }) {
+    let fingerprint = (image.len(), crc32fast::hash(&image));
+    if let Some(index) = deduplicator
+        .by_fingerprint
+        .get(&fingerprint)
+        .and_then(|candidates| {
+            candidates
+                .iter()
+                .copied()
+                .find(|index| image_bufs[*index].1 == image)
+        })
+    {
         pic.id = image_bufs[index].0.clone();
         return;
     }
@@ -47,7 +48,11 @@ fn collect_pic(
     let index = image_bufs.len();
     image_bufs.push((pic_id.clone(), image));
     deduplicator.by_id.insert(pic_id.clone(), index);
-    deduplicator.by_hash.entry(hash).or_default().push(index);
+    deduplicator
+        .by_fingerprint
+        .entry(fingerprint)
+        .or_default()
+        .push(index);
     pic.id = pic_id;
 }
 

--- a/docx-core/src/documents/mod.rs
+++ b/docx-core/src/documents/mod.rs
@@ -908,10 +908,15 @@ impl Docx {
         let mut counts: HashMap<String, usize> = HashMap::new();
         collect_para_ids_in_docx(self, &mut counts);
 
-        let mut used: HashSet<String> = counts.keys().cloned().collect();
+        let duplicates: HashSet<String> = counts
+            .iter()
+            .filter(|(_, count)| **count > 1)
+            .map(|(id, _)| id.clone())
+            .collect();
+        let mut used: HashSet<String> = counts.into_keys().collect();
         let mut seen: HashSet<String> = HashSet::new();
 
-        refresh_para_ids_in_docx(self, &counts, &mut used, &mut seen);
+        refresh_para_ids_in_docx(self, &duplicates, &mut used, &mut seen);
     }
 
     fn insert_comment_to_map(
@@ -1120,14 +1125,18 @@ impl Docx {
     // Traverse and clone comments from document and add to comments node.
     // reader only
     pub(crate) fn store_comments(&mut self, comments: &[Comment]) {
+        let comments_by_id: HashMap<usize, &Comment> = comments
+            .iter()
+            .map(|comment| (comment.id(), comment))
+            .collect();
         for child in &mut self.document.children {
             match child {
                 DocumentChild::Paragraph(paragraph) => {
                     for child in &mut paragraph.children {
                         if let ParagraphChild::CommentStart(ref mut c) = child {
                             let comment_id = c.get_id();
-                            if let Some(comment) = comments.iter().find(|c| c.id() == comment_id) {
-                                let comment = comment.clone();
+                            if let Some(comment) = comments_by_id.get(&comment_id).copied() {
+                                let comment = Comment::clone(comment);
                                 c.as_mut().comment(comment);
                             }
                         }
@@ -1135,10 +1144,9 @@ impl Docx {
                             for child in &mut insert.children {
                                 if let InsertChild::CommentStart(ref mut c) = child {
                                     let comment_id = c.get_id();
-                                    if let Some(comment) =
-                                        comments.iter().find(|c| c.id() == comment_id)
+                                    if let Some(comment) = comments_by_id.get(&comment_id).copied()
                                     {
-                                        let comment = comment.clone();
+                                        let comment = Comment::clone(comment);
                                         c.as_mut().comment(comment);
                                     }
                                 } else if let InsertChild::Delete(ref mut d) = child {
@@ -1146,9 +1154,9 @@ impl Docx {
                                         if let DeleteChild::CommentStart(ref mut c) = child {
                                             let comment_id = c.get_id();
                                             if let Some(comment) =
-                                                comments.iter().find(|c| c.id() == comment_id)
+                                                comments_by_id.get(&comment_id).copied()
                                             {
-                                                let comment = comment.clone();
+                                                let comment = Comment::clone(comment);
                                                 c.as_mut().comment(comment);
                                             }
                                         }
@@ -1160,10 +1168,9 @@ impl Docx {
                             for child in &mut delete.children {
                                 if let DeleteChild::CommentStart(ref mut c) = child {
                                     let comment_id = c.get_id();
-                                    if let Some(comment) =
-                                        comments.iter().find(|c| c.id() == comment_id)
+                                    if let Some(comment) = comments_by_id.get(&comment_id).copied()
                                     {
-                                        let comment = comment.clone();
+                                        let comment = Comment::clone(comment);
                                         c.as_mut().comment(comment);
                                     }
                                 }
@@ -1171,7 +1178,7 @@ impl Docx {
                         }
                     }
                 }
-                DocumentChild::Table(table) => store_comments_in_table(table, comments),
+                DocumentChild::Table(table) => store_comments_in_table(table, &comments_by_id),
                 _ => {}
             }
         }
@@ -1747,12 +1754,15 @@ fn collect_dependencies_in_table(
     }
 }
 
-fn store_comments_in_paragraph(paragraph: &mut Paragraph, comments: &[Comment]) {
+fn store_comments_in_paragraph(
+    paragraph: &mut Paragraph,
+    comments_by_id: &HashMap<usize, &Comment>,
+) {
     for child in &mut paragraph.children {
         if let ParagraphChild::CommentStart(ref mut c) = child {
             let comment_id = c.get_id();
-            if let Some(comment) = comments.iter().find(|c| c.id() == comment_id) {
-                let comment = comment.clone();
+            if let Some(comment) = comments_by_id.get(&comment_id).copied() {
+                let comment = Comment::clone(comment);
                 c.as_mut().comment(comment);
             }
         }
@@ -1760,8 +1770,8 @@ fn store_comments_in_paragraph(paragraph: &mut Paragraph, comments: &[Comment]) 
             for child in &mut insert.children {
                 if let InsertChild::CommentStart(ref mut c) = child {
                     let comment_id = c.get_id();
-                    if let Some(comment) = comments.iter().find(|c| c.id() == comment_id) {
-                        let comment = comment.clone();
+                    if let Some(comment) = comments_by_id.get(&comment_id).copied() {
+                        let comment = Comment::clone(comment);
                         c.as_mut().comment(comment);
                     }
                 }
@@ -1771,8 +1781,8 @@ fn store_comments_in_paragraph(paragraph: &mut Paragraph, comments: &[Comment]) 
             for child in &mut delete.children {
                 if let DeleteChild::CommentStart(ref mut c) = child {
                     let comment_id = c.get_id();
-                    if let Some(comment) = comments.iter().find(|c| c.id() == comment_id) {
-                        let comment = comment.clone();
+                    if let Some(comment) = comments_by_id.get(&comment_id).copied() {
+                        let comment = Comment::clone(comment);
                         c.as_mut().comment(comment);
                     }
                 }
@@ -1781,43 +1791,43 @@ fn store_comments_in_paragraph(paragraph: &mut Paragraph, comments: &[Comment]) 
     }
 }
 
-fn store_comments_in_table(table: &mut Table, comments: &[Comment]) {
+fn store_comments_in_table(table: &mut Table, comments_by_id: &HashMap<usize, &Comment>) {
     for TableChild::TableRow(row) in &mut table.rows {
         for TableRowChild::TableCell(cell) in &mut row.cells {
             for content in &mut cell.children {
                 match content {
                     TableCellContent::Paragraph(paragraph) => {
-                        store_comments_in_paragraph(paragraph, comments)
+                        store_comments_in_paragraph(paragraph, comments_by_id)
                     }
                     TableCellContent::Table(ref mut table) => {
-                        store_comments_in_table(table, comments);
+                        store_comments_in_table(table, comments_by_id);
                     }
                     TableCellContent::StructuredDataTag(ref mut tag) => {
                         for child in &mut tag.children {
                             if let StructuredDataTagChild::Paragraph(paragraph) = child {
-                                store_comments_in_paragraph(paragraph, comments);
+                                store_comments_in_paragraph(paragraph, comments_by_id);
                             }
                             if let StructuredDataTagChild::Table(table) = child {
-                                store_comments_in_table(table, comments);
+                                store_comments_in_table(table, comments_by_id);
                             }
                         }
                     }
                     TableCellContent::TableOfContents(ref mut t) => {
                         for child in &mut t.before_contents {
                             if let TocContent::Paragraph(paragraph) = child {
-                                store_comments_in_paragraph(paragraph, comments);
+                                store_comments_in_paragraph(paragraph, comments_by_id);
                             }
                             if let TocContent::Table(table) = child {
-                                store_comments_in_table(table, comments);
+                                store_comments_in_table(table, comments_by_id);
                             }
                         }
 
                         for child in &mut t.after_contents {
                             if let TocContent::Paragraph(paragraph) = child {
-                                store_comments_in_paragraph(paragraph, comments);
+                                store_comments_in_paragraph(paragraph, comments_by_id);
                             }
                             if let TocContent::Table(table) = child {
-                                store_comments_in_table(table, comments);
+                                store_comments_in_table(table, comments_by_id);
                             }
                         }
                     }
@@ -2037,108 +2047,117 @@ fn collect_para_ids_in_comment(comment: &Comment, counts: &mut HashMap<String, u
 
 fn refresh_para_ids_in_docx(
     docx: &mut Docx,
-    counts: &HashMap<String, usize>,
+    duplicates: &HashSet<String>,
     used: &mut HashSet<String>,
     seen: &mut HashSet<String>,
 ) {
     for child in &mut docx.document.children {
-        refresh_para_ids_in_document_child(child, counts, used, seen);
+        refresh_para_ids_in_document_child(child, duplicates, used, seen);
     }
-    refresh_para_ids_in_section_property(&mut docx.document.section_property, counts, used, seen);
+    refresh_para_ids_in_section_property(
+        &mut docx.document.section_property,
+        duplicates,
+        used,
+        seen,
+    );
 
     for comment in &mut docx.comments.comments {
-        refresh_para_ids_in_comment(comment, counts, used, seen);
+        refresh_para_ids_in_comment(comment, duplicates, used, seen);
     }
 
     for footnote in &mut docx.footnotes.footnotes {
         for paragraph in &mut footnote.content {
-            refresh_para_ids_in_paragraph(paragraph, counts, used, seen);
+            refresh_para_ids_in_paragraph(paragraph, duplicates, used, seen);
         }
     }
 }
 
 fn refresh_para_ids_in_document_child(
     child: &mut DocumentChild,
-    counts: &HashMap<String, usize>,
+    duplicates: &HashSet<String>,
     used: &mut HashSet<String>,
     seen: &mut HashSet<String>,
 ) {
     match child {
         DocumentChild::Paragraph(paragraph) => {
-            refresh_para_ids_in_paragraph(paragraph, counts, used, seen)
+            refresh_para_ids_in_paragraph(paragraph, duplicates, used, seen)
         }
-        DocumentChild::Table(table) => refresh_para_ids_in_table(table, counts, used, seen),
+        DocumentChild::Table(table) => refresh_para_ids_in_table(table, duplicates, used, seen),
         DocumentChild::StructuredDataTag(tag) => {
-            refresh_para_ids_in_structured_data_tag(tag, counts, used, seen)
+            refresh_para_ids_in_structured_data_tag(tag, duplicates, used, seen)
         }
-        DocumentChild::TableOfContents(toc) => refresh_para_ids_in_toc(toc, counts, used, seen),
-        DocumentChild::Section(section) => refresh_para_ids_in_section(section, counts, used, seen),
+        DocumentChild::TableOfContents(toc) => refresh_para_ids_in_toc(toc, duplicates, used, seen),
+        DocumentChild::Section(section) => {
+            refresh_para_ids_in_section(section, duplicates, used, seen)
+        }
         _ => {}
     }
 }
 
 fn refresh_para_ids_in_section(
     section: &mut Section,
-    counts: &HashMap<String, usize>,
+    duplicates: &HashSet<String>,
     used: &mut HashSet<String>,
     seen: &mut HashSet<String>,
 ) {
     for child in &mut section.children {
         match child {
             SectionChild::Paragraph(paragraph) => {
-                refresh_para_ids_in_paragraph(paragraph, counts, used, seen)
+                refresh_para_ids_in_paragraph(paragraph, duplicates, used, seen)
             }
-            SectionChild::Table(table) => refresh_para_ids_in_table(table, counts, used, seen),
+            SectionChild::Table(table) => refresh_para_ids_in_table(table, duplicates, used, seen),
             SectionChild::StructuredDataTag(tag) => {
-                refresh_para_ids_in_structured_data_tag(tag, counts, used, seen)
+                refresh_para_ids_in_structured_data_tag(tag, duplicates, used, seen)
             }
-            SectionChild::TableOfContents(toc) => refresh_para_ids_in_toc(toc, counts, used, seen),
+            SectionChild::TableOfContents(toc) => {
+                refresh_para_ids_in_toc(toc, duplicates, used, seen)
+            }
             _ => {}
         }
     }
-    refresh_para_ids_in_section_property(&mut section.property, counts, used, seen);
+    refresh_para_ids_in_section_property(&mut section.property, duplicates, used, seen);
 }
 
 fn refresh_para_ids_in_section_property(
     property: &mut SectionProperty,
-    counts: &HashMap<String, usize>,
+    duplicates: &HashSet<String>,
     used: &mut HashSet<String>,
     seen: &mut HashSet<String>,
 ) {
     if let Some((_, header)) = property.header.as_mut() {
-        refresh_para_ids_in_header(header, counts, used, seen);
+        refresh_para_ids_in_header(header, duplicates, used, seen);
     }
     if let Some((_, header)) = property.first_header.as_mut() {
-        refresh_para_ids_in_header(header, counts, used, seen);
+        refresh_para_ids_in_header(header, duplicates, used, seen);
     }
     if let Some((_, header)) = property.even_header.as_mut() {
-        refresh_para_ids_in_header(header, counts, used, seen);
+        refresh_para_ids_in_header(header, duplicates, used, seen);
     }
     if let Some((_, footer)) = property.footer.as_mut() {
-        refresh_para_ids_in_footer(footer, counts, used, seen);
+        refresh_para_ids_in_footer(footer, duplicates, used, seen);
     }
     if let Some((_, footer)) = property.first_footer.as_mut() {
-        refresh_para_ids_in_footer(footer, counts, used, seen);
+        refresh_para_ids_in_footer(footer, duplicates, used, seen);
     }
     if let Some((_, footer)) = property.even_footer.as_mut() {
-        refresh_para_ids_in_footer(footer, counts, used, seen);
+        refresh_para_ids_in_footer(footer, duplicates, used, seen);
     }
 }
 
 fn refresh_para_ids_in_header(
     header: &mut Header,
-    counts: &HashMap<String, usize>,
+    duplicates: &HashSet<String>,
     used: &mut HashSet<String>,
     seen: &mut HashSet<String>,
 ) {
     for child in &mut header.children {
         match child {
             HeaderChild::Paragraph(paragraph) => {
-                refresh_para_ids_in_paragraph(paragraph, counts, used, seen)
+                refresh_para_ids_in_paragraph(paragraph, duplicates, used, seen)
             }
-            HeaderChild::Table(table) => refresh_para_ids_in_table(table, counts, used, seen),
+            HeaderChild::Table(table) => refresh_para_ids_in_table(table, duplicates, used, seen),
             HeaderChild::StructuredDataTag(tag) => {
-                refresh_para_ids_in_structured_data_tag(tag, counts, used, seen)
+                refresh_para_ids_in_structured_data_tag(tag, duplicates, used, seen)
             }
         }
     }
@@ -2146,18 +2165,18 @@ fn refresh_para_ids_in_header(
 
 fn refresh_para_ids_in_footer(
     footer: &mut Footer,
-    counts: &HashMap<String, usize>,
+    duplicates: &HashSet<String>,
     used: &mut HashSet<String>,
     seen: &mut HashSet<String>,
 ) {
     for child in &mut footer.children {
         match child {
             FooterChild::Paragraph(paragraph) => {
-                refresh_para_ids_in_paragraph(paragraph, counts, used, seen)
+                refresh_para_ids_in_paragraph(paragraph, duplicates, used, seen)
             }
-            FooterChild::Table(table) => refresh_para_ids_in_table(table, counts, used, seen),
+            FooterChild::Table(table) => refresh_para_ids_in_table(table, duplicates, used, seen),
             FooterChild::StructuredDataTag(tag) => {
-                refresh_para_ids_in_structured_data_tag(tag, counts, used, seen)
+                refresh_para_ids_in_structured_data_tag(tag, duplicates, used, seen)
             }
         }
     }
@@ -2165,31 +2184,31 @@ fn refresh_para_ids_in_footer(
 
 fn refresh_para_ids_in_toc(
     toc: &mut TableOfContents,
-    counts: &HashMap<String, usize>,
+    duplicates: &HashSet<String>,
     used: &mut HashSet<String>,
     seen: &mut HashSet<String>,
 ) {
     for child in &mut toc.before_contents {
         match child {
             TocContent::Paragraph(paragraph) => {
-                refresh_para_ids_in_paragraph(paragraph, counts, used, seen)
+                refresh_para_ids_in_paragraph(paragraph, duplicates, used, seen)
             }
-            TocContent::Table(table) => refresh_para_ids_in_table(table, counts, used, seen),
+            TocContent::Table(table) => refresh_para_ids_in_table(table, duplicates, used, seen),
         }
     }
     for child in &mut toc.after_contents {
         match child {
             TocContent::Paragraph(paragraph) => {
-                refresh_para_ids_in_paragraph(paragraph, counts, used, seen)
+                refresh_para_ids_in_paragraph(paragraph, duplicates, used, seen)
             }
-            TocContent::Table(table) => refresh_para_ids_in_table(table, counts, used, seen),
+            TocContent::Table(table) => refresh_para_ids_in_table(table, duplicates, used, seen),
         }
     }
 }
 
 fn refresh_para_ids_in_table(
     table: &mut Table,
-    counts: &HashMap<String, usize>,
+    duplicates: &HashSet<String>,
     used: &mut HashSet<String>,
     seen: &mut HashSet<String>,
 ) {
@@ -2198,16 +2217,16 @@ fn refresh_para_ids_in_table(
             for content in &mut cell.children {
                 match content {
                     TableCellContent::Paragraph(paragraph) => {
-                        refresh_para_ids_in_paragraph(paragraph, counts, used, seen)
+                        refresh_para_ids_in_paragraph(paragraph, duplicates, used, seen)
                     }
                     TableCellContent::Table(table) => {
-                        refresh_para_ids_in_table(table, counts, used, seen)
+                        refresh_para_ids_in_table(table, duplicates, used, seen)
                     }
                     TableCellContent::StructuredDataTag(tag) => {
-                        refresh_para_ids_in_structured_data_tag(tag, counts, used, seen)
+                        refresh_para_ids_in_structured_data_tag(tag, duplicates, used, seen)
                     }
                     TableCellContent::TableOfContents(toc) => {
-                        refresh_para_ids_in_toc(toc, counts, used, seen)
+                        refresh_para_ids_in_toc(toc, duplicates, used, seen)
                     }
                 }
             }
@@ -2217,28 +2236,28 @@ fn refresh_para_ids_in_table(
 
 fn refresh_para_ids_in_paragraph(
     paragraph: &mut Paragraph,
-    counts: &HashMap<String, usize>,
+    duplicates: &HashSet<String>,
     used: &mut HashSet<String>,
     seen: &mut HashSet<String>,
 ) {
-    ensure_unique_paragraph_id(paragraph, counts, used, seen);
+    ensure_unique_paragraph_id(paragraph, duplicates, used, seen);
 
     for child in &mut paragraph.children {
         match child {
             ParagraphChild::CommentStart(c) => {
-                refresh_para_ids_in_comment(&mut c.comment, counts, used, seen)
+                refresh_para_ids_in_comment(&mut c.comment, duplicates, used, seen)
             }
             ParagraphChild::Insert(insert) => {
-                refresh_para_ids_in_insert(insert, counts, used, seen)
+                refresh_para_ids_in_insert(insert, duplicates, used, seen)
             }
             ParagraphChild::Delete(delete) => {
-                refresh_para_ids_in_delete(delete, counts, used, seen)
+                refresh_para_ids_in_delete(delete, duplicates, used, seen)
             }
             ParagraphChild::Hyperlink(hyperlink) => {
-                refresh_para_ids_in_hyperlink(hyperlink, counts, used, seen)
+                refresh_para_ids_in_hyperlink(hyperlink, duplicates, used, seen)
             }
             ParagraphChild::StructuredDataTag(tag) => {
-                refresh_para_ids_in_structured_data_tag(tag, counts, used, seen)
+                refresh_para_ids_in_structured_data_tag(tag, duplicates, used, seen)
             }
             _ => {}
         }
@@ -2247,23 +2266,23 @@ fn refresh_para_ids_in_paragraph(
 
 fn refresh_para_ids_in_hyperlink(
     hyperlink: &mut Hyperlink,
-    counts: &HashMap<String, usize>,
+    duplicates: &HashSet<String>,
     used: &mut HashSet<String>,
     seen: &mut HashSet<String>,
 ) {
     for child in &mut hyperlink.children {
         match child {
             ParagraphChild::CommentStart(c) => {
-                refresh_para_ids_in_comment(&mut c.comment, counts, used, seen)
+                refresh_para_ids_in_comment(&mut c.comment, duplicates, used, seen)
             }
             ParagraphChild::Insert(insert) => {
-                refresh_para_ids_in_insert(insert, counts, used, seen)
+                refresh_para_ids_in_insert(insert, duplicates, used, seen)
             }
             ParagraphChild::Delete(delete) => {
-                refresh_para_ids_in_delete(delete, counts, used, seen)
+                refresh_para_ids_in_delete(delete, duplicates, used, seen)
             }
             ParagraphChild::StructuredDataTag(tag) => {
-                refresh_para_ids_in_structured_data_tag(tag, counts, used, seen)
+                refresh_para_ids_in_structured_data_tag(tag, duplicates, used, seen)
             }
             _ => {}
         }
@@ -2272,16 +2291,18 @@ fn refresh_para_ids_in_hyperlink(
 
 fn refresh_para_ids_in_insert(
     insert: &mut Insert,
-    counts: &HashMap<String, usize>,
+    duplicates: &HashSet<String>,
     used: &mut HashSet<String>,
     seen: &mut HashSet<String>,
 ) {
     for child in &mut insert.children {
         match child {
             InsertChild::CommentStart(c) => {
-                refresh_para_ids_in_comment(&mut c.comment, counts, used, seen)
+                refresh_para_ids_in_comment(&mut c.comment, duplicates, used, seen)
             }
-            InsertChild::Delete(delete) => refresh_para_ids_in_delete(delete, counts, used, seen),
+            InsertChild::Delete(delete) => {
+                refresh_para_ids_in_delete(delete, duplicates, used, seen)
+            }
             _ => {}
         }
     }
@@ -2289,36 +2310,36 @@ fn refresh_para_ids_in_insert(
 
 fn refresh_para_ids_in_delete(
     delete: &mut Delete,
-    counts: &HashMap<String, usize>,
+    duplicates: &HashSet<String>,
     used: &mut HashSet<String>,
     seen: &mut HashSet<String>,
 ) {
     for child in &mut delete.children {
         if let DeleteChild::CommentStart(c) = child {
-            refresh_para_ids_in_comment(&mut c.comment, counts, used, seen);
+            refresh_para_ids_in_comment(&mut c.comment, duplicates, used, seen);
         }
     }
 }
 
 fn refresh_para_ids_in_structured_data_tag(
     tag: &mut StructuredDataTag,
-    counts: &HashMap<String, usize>,
+    duplicates: &HashSet<String>,
     used: &mut HashSet<String>,
     seen: &mut HashSet<String>,
 ) {
     for child in &mut tag.children {
         match child {
             StructuredDataTagChild::Paragraph(paragraph) => {
-                refresh_para_ids_in_paragraph(paragraph, counts, used, seen)
+                refresh_para_ids_in_paragraph(paragraph, duplicates, used, seen)
             }
             StructuredDataTagChild::Table(table) => {
-                refresh_para_ids_in_table(table, counts, used, seen)
+                refresh_para_ids_in_table(table, duplicates, used, seen)
             }
             StructuredDataTagChild::CommentStart(c) => {
-                refresh_para_ids_in_comment(&mut c.comment, counts, used, seen)
+                refresh_para_ids_in_comment(&mut c.comment, duplicates, used, seen)
             }
             StructuredDataTagChild::StructuredDataTag(inner) => {
-                refresh_para_ids_in_structured_data_tag(inner, counts, used, seen)
+                refresh_para_ids_in_structured_data_tag(inner, duplicates, used, seen)
             }
             _ => {}
         }
@@ -2327,34 +2348,30 @@ fn refresh_para_ids_in_structured_data_tag(
 
 fn refresh_para_ids_in_comment(
     comment: &mut Comment,
-    counts: &HashMap<String, usize>,
+    duplicates: &HashSet<String>,
     used: &mut HashSet<String>,
     seen: &mut HashSet<String>,
 ) {
     for child in &mut comment.children {
         match child {
             CommentChild::Paragraph(paragraph) => {
-                refresh_para_ids_in_paragraph(paragraph, counts, used, seen)
+                refresh_para_ids_in_paragraph(paragraph, duplicates, used, seen)
             }
-            CommentChild::Table(table) => refresh_para_ids_in_table(table, counts, used, seen),
+            CommentChild::Table(table) => refresh_para_ids_in_table(table, duplicates, used, seen),
         }
     }
 }
 
 fn ensure_unique_paragraph_id(
     paragraph: &mut Paragraph,
-    counts: &HashMap<String, usize>,
+    duplicates: &HashSet<String>,
     used: &mut HashSet<String>,
     seen: &mut HashSet<String>,
 ) {
-    let id = paragraph.id.clone();
-    let count = counts.get(&id).copied().unwrap_or(0);
-
-    if !id.is_empty() && count <= 1 {
+    if !paragraph.id.is_empty() && !duplicates.contains(&paragraph.id) {
         return;
     }
-    if !id.is_empty() && count > 1 && !seen.contains(&id) {
-        seen.insert(id);
+    if !paragraph.id.is_empty() && seen.insert(paragraph.id.clone()) {
         return;
     }
 

--- a/docx-core/src/documents/mod.rs
+++ b/docx-core/src/documents/mod.rs
@@ -922,15 +922,20 @@ impl Docx {
     }
 
     fn refresh_duplicate_para_ids(&mut self) {
-        let mut counts: HashMap<String, usize> = HashMap::new();
+        let mut counts: HashMap<&str, usize> = HashMap::new();
         collect_para_ids_in_docx(self, &mut counts);
 
         let duplicates: HashSet<String> = counts
             .iter()
             .filter(|(_, count)| **count > 1)
-            .map(|(id, _)| id.clone())
+            .map(|(id, _)| (*id).to_owned())
             .collect();
-        let mut used: HashSet<String> = counts.into_keys().collect();
+        let has_empty_id = counts.contains_key("");
+        if duplicates.is_empty() && !has_empty_id {
+            return;
+        }
+
+        let mut used: HashSet<String> = counts.into_keys().map(str::to_owned).collect();
         let mut seen: HashSet<String> = HashSet::new();
 
         refresh_para_ids_in_docx(self, &duplicates, &mut used, &mut seen);
@@ -968,6 +973,9 @@ impl Docx {
                             self.insert_comment_to_map(&mut comment_map, c);
                         }
                         if let ParagraphChild::Hyperlink(h) = child {
+                            if let HyperlinkData::External { rid, path } = &h.link {
+                                hyperlink_map.insert(rid.clone(), path.clone());
+                            }
                             for child in &h.children {
                                 if let ParagraphChild::CommentStart(c) = child {
                                     self.insert_comment_to_map(&mut comment_map, c);
@@ -977,28 +985,53 @@ impl Docx {
                     }
                 }
                 DocumentChild::Table(table) => {
-                    collect_comment_map_in_table(table, &mut comment_map);
+                    collect_comment_map_in_table(table, &mut comment_map, &mut hyperlink_map);
                 }
                 DocumentChild::TableOfContents(toc) => {
                     for child in &toc.before_contents {
                         if let TocContent::Paragraph(paragraph) = child {
-                            collect_comment_map_in_paragraph(paragraph, &mut comment_map);
+                            collect_comment_map_in_paragraph(
+                                paragraph,
+                                &mut comment_map,
+                                &mut hyperlink_map,
+                            );
                         }
                         if let TocContent::Table(table) = child {
-                            collect_comment_map_in_table(table, &mut comment_map);
+                            collect_comment_map_in_table(
+                                table,
+                                &mut comment_map,
+                                &mut hyperlink_map,
+                            );
                         }
                     }
                     for child in &toc.after_contents {
                         if let TocContent::Paragraph(paragraph) = child {
-                            collect_comment_map_in_paragraph(paragraph, &mut comment_map);
+                            collect_comment_map_in_paragraph(
+                                paragraph,
+                                &mut comment_map,
+                                &mut hyperlink_map,
+                            );
                         }
                         if let TocContent::Table(table) = child {
-                            collect_comment_map_in_table(table, &mut comment_map);
+                            collect_comment_map_in_table(
+                                table,
+                                &mut comment_map,
+                                &mut hyperlink_map,
+                            );
                         }
                     }
                 }
                 _ => {}
             }
+        }
+
+        if comment_map.is_empty() {
+            for (id, path) in hyperlink_map {
+                self.document_rels
+                    .hyperlinks
+                    .push((id, path, "External".to_owned()));
+            }
+            return;
         }
 
         for child in &self.document.children {
@@ -1601,6 +1634,7 @@ fn collect_dependencies_in_paragraph(
 fn collect_comment_map_in_paragraph(
     paragraph: &Paragraph,
     comment_map: &mut HashMap<usize, String>,
+    hyperlink_map: &mut HashMap<String, String>,
 ) {
     for child in &paragraph.children {
         if let ParagraphChild::CommentStart(c) = child {
@@ -1613,6 +1647,9 @@ fn collect_comment_map_in_paragraph(
             }
         }
         if let ParagraphChild::Hyperlink(h) = child {
+            if let HyperlinkData::External { rid, path } = &h.link {
+                hyperlink_map.insert(rid.clone(), path.clone());
+            }
             for child in &h.children {
                 if let ParagraphChild::CommentStart(c) = child {
                     let comment = c.get_comment_ref();
@@ -1628,42 +1665,58 @@ fn collect_comment_map_in_paragraph(
     }
 }
 
-fn collect_comment_map_in_table(table: &Table, comment_map: &mut HashMap<usize, String>) {
+fn collect_comment_map_in_table(
+    table: &Table,
+    comment_map: &mut HashMap<usize, String>,
+    hyperlink_map: &mut HashMap<String, String>,
+) {
     for TableChild::TableRow(row) in &table.rows {
         for TableRowChild::TableCell(cell) in &row.cells {
             for content in &cell.children {
                 match content {
                     TableCellContent::Paragraph(paragraph) => {
-                        collect_comment_map_in_paragraph(paragraph, comment_map);
+                        collect_comment_map_in_paragraph(paragraph, comment_map, hyperlink_map);
                     }
                     TableCellContent::Table(table) => {
-                        collect_comment_map_in_table(table, comment_map)
+                        collect_comment_map_in_table(table, comment_map, hyperlink_map)
                     }
                     TableCellContent::StructuredDataTag(tag) => {
                         for child in &tag.children {
                             if let StructuredDataTagChild::Paragraph(paragraph) = child {
-                                collect_comment_map_in_paragraph(paragraph, comment_map);
+                                collect_comment_map_in_paragraph(
+                                    paragraph,
+                                    comment_map,
+                                    hyperlink_map,
+                                );
                             }
                             if let StructuredDataTagChild::Table(table) = child {
-                                collect_comment_map_in_table(table, comment_map);
+                                collect_comment_map_in_table(table, comment_map, hyperlink_map);
                             }
                         }
                     }
                     TableCellContent::TableOfContents(t) => {
                         for child in &t.before_contents {
                             if let TocContent::Paragraph(paragraph) = child {
-                                collect_comment_map_in_paragraph(paragraph, comment_map);
+                                collect_comment_map_in_paragraph(
+                                    paragraph,
+                                    comment_map,
+                                    hyperlink_map,
+                                );
                             }
                             if let TocContent::Table(table) = child {
-                                collect_comment_map_in_table(table, comment_map);
+                                collect_comment_map_in_table(table, comment_map, hyperlink_map);
                             }
                         }
                         for child in &t.after_contents {
                             if let TocContent::Paragraph(paragraph) = child {
-                                collect_comment_map_in_paragraph(paragraph, comment_map);
+                                collect_comment_map_in_paragraph(
+                                    paragraph,
+                                    comment_map,
+                                    hyperlink_map,
+                                );
                             }
                             if let TocContent::Table(table) = child {
-                                collect_comment_map_in_table(table, comment_map);
+                                collect_comment_map_in_table(table, comment_map, hyperlink_map);
                             }
                         }
                     }
@@ -1854,7 +1907,7 @@ fn store_comments_in_table(table: &mut Table, comments_by_id: &HashMap<usize, &C
     }
 }
 
-fn collect_para_ids_in_docx(docx: &Docx, counts: &mut HashMap<String, usize>) {
+fn collect_para_ids_in_docx<'a>(docx: &'a Docx, counts: &mut HashMap<&'a str, usize>) {
     for child in &docx.document.children {
         collect_para_ids_in_document_child(child, counts);
     }
@@ -1871,7 +1924,10 @@ fn collect_para_ids_in_docx(docx: &Docx, counts: &mut HashMap<String, usize>) {
     }
 }
 
-fn collect_para_ids_in_document_child(child: &DocumentChild, counts: &mut HashMap<String, usize>) {
+fn collect_para_ids_in_document_child<'a>(
+    child: &'a DocumentChild,
+    counts: &mut HashMap<&'a str, usize>,
+) {
     match child {
         DocumentChild::Paragraph(paragraph) => collect_para_ids_in_paragraph(paragraph, counts),
         DocumentChild::Table(table) => collect_para_ids_in_table(table, counts),
@@ -1884,7 +1940,7 @@ fn collect_para_ids_in_document_child(child: &DocumentChild, counts: &mut HashMa
     }
 }
 
-fn collect_para_ids_in_section(section: &Section, counts: &mut HashMap<String, usize>) {
+fn collect_para_ids_in_section<'a>(section: &'a Section, counts: &mut HashMap<&'a str, usize>) {
     for child in &section.children {
         match child {
             SectionChild::Paragraph(paragraph) => collect_para_ids_in_paragraph(paragraph, counts),
@@ -1899,9 +1955,9 @@ fn collect_para_ids_in_section(section: &Section, counts: &mut HashMap<String, u
     collect_para_ids_in_section_property(&section.property, counts);
 }
 
-fn collect_para_ids_in_section_property(
-    property: &SectionProperty,
-    counts: &mut HashMap<String, usize>,
+fn collect_para_ids_in_section_property<'a>(
+    property: &'a SectionProperty,
+    counts: &mut HashMap<&'a str, usize>,
 ) {
     if let Some((_, header)) = property.header.as_ref() {
         collect_para_ids_in_header(header, counts);
@@ -1923,7 +1979,7 @@ fn collect_para_ids_in_section_property(
     }
 }
 
-fn collect_para_ids_in_header(header: &Header, counts: &mut HashMap<String, usize>) {
+fn collect_para_ids_in_header<'a>(header: &'a Header, counts: &mut HashMap<&'a str, usize>) {
     for child in &header.children {
         match child {
             HeaderChild::Paragraph(paragraph) => collect_para_ids_in_paragraph(paragraph, counts),
@@ -1935,7 +1991,7 @@ fn collect_para_ids_in_header(header: &Header, counts: &mut HashMap<String, usiz
     }
 }
 
-fn collect_para_ids_in_footer(footer: &Footer, counts: &mut HashMap<String, usize>) {
+fn collect_para_ids_in_footer<'a>(footer: &'a Footer, counts: &mut HashMap<&'a str, usize>) {
     for child in &footer.children {
         match child {
             FooterChild::Paragraph(paragraph) => collect_para_ids_in_paragraph(paragraph, counts),
@@ -1947,7 +2003,7 @@ fn collect_para_ids_in_footer(footer: &Footer, counts: &mut HashMap<String, usiz
     }
 }
 
-fn collect_para_ids_in_toc(toc: &TableOfContents, counts: &mut HashMap<String, usize>) {
+fn collect_para_ids_in_toc<'a>(toc: &'a TableOfContents, counts: &mut HashMap<&'a str, usize>) {
     for child in &toc.before_contents {
         match child {
             TocContent::Paragraph(paragraph) => collect_para_ids_in_paragraph(paragraph, counts),
@@ -1962,7 +2018,7 @@ fn collect_para_ids_in_toc(toc: &TableOfContents, counts: &mut HashMap<String, u
     }
 }
 
-fn collect_para_ids_in_table(table: &Table, counts: &mut HashMap<String, usize>) {
+fn collect_para_ids_in_table<'a>(table: &'a Table, counts: &mut HashMap<&'a str, usize>) {
     for TableChild::TableRow(row) in &table.rows {
         for TableRowChild::TableCell(cell) in &row.cells {
             for content in &cell.children {
@@ -1981,8 +2037,11 @@ fn collect_para_ids_in_table(table: &Table, counts: &mut HashMap<String, usize>)
     }
 }
 
-fn collect_para_ids_in_paragraph(paragraph: &Paragraph, counts: &mut HashMap<String, usize>) {
-    *counts.entry(paragraph.id.clone()).or_insert(0) += 1;
+fn collect_para_ids_in_paragraph<'a>(
+    paragraph: &'a Paragraph,
+    counts: &mut HashMap<&'a str, usize>,
+) {
+    *counts.entry(paragraph.id.as_str()).or_insert(0) += 1;
 
     for child in &paragraph.children {
         match child {
@@ -2000,7 +2059,10 @@ fn collect_para_ids_in_paragraph(paragraph: &Paragraph, counts: &mut HashMap<Str
     }
 }
 
-fn collect_para_ids_in_hyperlink(hyperlink: &Hyperlink, counts: &mut HashMap<String, usize>) {
+fn collect_para_ids_in_hyperlink<'a>(
+    hyperlink: &'a Hyperlink,
+    counts: &mut HashMap<&'a str, usize>,
+) {
     for child in &hyperlink.children {
         match child {
             ParagraphChild::CommentStart(c) => collect_para_ids_in_comment(&c.comment, counts),
@@ -2014,7 +2076,7 @@ fn collect_para_ids_in_hyperlink(hyperlink: &Hyperlink, counts: &mut HashMap<Str
     }
 }
 
-fn collect_para_ids_in_insert(insert: &Insert, counts: &mut HashMap<String, usize>) {
+fn collect_para_ids_in_insert<'a>(insert: &'a Insert, counts: &mut HashMap<&'a str, usize>) {
     for child in &insert.children {
         match child {
             InsertChild::CommentStart(c) => collect_para_ids_in_comment(&c.comment, counts),
@@ -2024,7 +2086,7 @@ fn collect_para_ids_in_insert(insert: &Insert, counts: &mut HashMap<String, usiz
     }
 }
 
-fn collect_para_ids_in_delete(delete: &Delete, counts: &mut HashMap<String, usize>) {
+fn collect_para_ids_in_delete<'a>(delete: &'a Delete, counts: &mut HashMap<&'a str, usize>) {
     for child in &delete.children {
         if let DeleteChild::CommentStart(c) = child {
             collect_para_ids_in_comment(&c.comment, counts);
@@ -2032,9 +2094,9 @@ fn collect_para_ids_in_delete(delete: &Delete, counts: &mut HashMap<String, usiz
     }
 }
 
-fn collect_para_ids_in_structured_data_tag(
-    tag: &StructuredDataTag,
-    counts: &mut HashMap<String, usize>,
+fn collect_para_ids_in_structured_data_tag<'a>(
+    tag: &'a StructuredDataTag,
+    counts: &mut HashMap<&'a str, usize>,
 ) {
     for child in &tag.children {
         match child {
@@ -2053,7 +2115,7 @@ fn collect_para_ids_in_structured_data_tag(
     }
 }
 
-fn collect_para_ids_in_comment(comment: &Comment, counts: &mut HashMap<String, usize>) {
+fn collect_para_ids_in_comment<'a>(comment: &'a Comment, counts: &mut HashMap<&'a str, usize>) {
     for child in &comment.children {
         match child {
             CommentChild::Paragraph(paragraph) => collect_para_ids_in_paragraph(paragraph, counts),
@@ -2523,6 +2585,56 @@ fn update_document_by_toc(
     toc.items = items;
     children[toc_index] = DocumentChild::TableOfContents(Box::new(toc));
     children
+}
+
+#[cfg(test)]
+mod paragraph_id_tests {
+    use super::*;
+
+    fn paragraph_ids(docx: &Docx) -> Vec<&str> {
+        docx.document
+            .children
+            .iter()
+            .filter_map(|child| match child {
+                DocumentChild::Paragraph(paragraph) => Some(paragraph.id.as_str()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn unique_paragraph_ids_remain_unchanged() {
+        let mut docx = Docx::new()
+            .add_paragraph(Paragraph::new().id("first"))
+            .add_paragraph(Paragraph::new().id("second"));
+
+        docx.refresh_duplicate_para_ids();
+
+        assert_eq!(paragraph_ids(&docx), ["first", "second"]);
+    }
+
+    #[test]
+    fn duplicate_paragraph_ids_are_refreshed() {
+        let mut docx = Docx::new()
+            .add_paragraph(Paragraph::new().id("duplicate"))
+            .add_paragraph(Paragraph::new().id("duplicate"));
+
+        docx.refresh_duplicate_para_ids();
+
+        let ids = paragraph_ids(&docx);
+        assert_eq!(ids[0], "duplicate");
+        assert_ne!(ids[1], "duplicate");
+        assert_eq!(ids.iter().copied().collect::<HashSet<_>>().len(), 2);
+    }
+
+    #[test]
+    fn empty_paragraph_id_is_refreshed() {
+        let mut docx = Docx::new().add_paragraph(Paragraph::new().id(""));
+
+        docx.refresh_duplicate_para_ids();
+
+        assert!(!paragraph_ids(&docx)[0].is_empty());
+    }
 }
 
 #[cfg(test)]

--- a/docx-core/src/documents/mod.rs
+++ b/docx-core/src/documents/mod.rs
@@ -84,7 +84,9 @@ pub use xml_docx::*;
 use base64::Engine;
 use serde::{ser, Serialize};
 
-use self::image_collector::{collect_images_from_paragraph, collect_images_from_table};
+use self::image_collector::{
+    collect_images_from_paragraph, collect_images_from_table, ImageDeduplicator,
+};
 
 #[derive(Debug, Clone)]
 pub struct Image(pub Vec<u8>);
@@ -101,6 +103,8 @@ pub struct Png(pub Vec<u8>);
 
 pub type ImageIdAndPath = (String, String);
 pub type ImageIdAndBuf = (String, Vec<u8>);
+
+const PNG_SIGNATURE: &[u8; 8] = &[137, 80, 78, 71, 13, 10, 26, 10];
 
 fn is_emf(path: &str, buf: &[u8]) -> bool {
     if path.to_ascii_lowercase().ends_with(".emf") {
@@ -279,6 +283,12 @@ impl Docx {
             return self;
         }
 
+        if buf.starts_with(PNG_SIGNATURE) {
+            self.images
+                .push((id.into(), path, Image(buf.clone()), Png(buf)));
+            return self;
+        }
+
         #[cfg(feature = "image")]
         if let Ok(dimg) = image::load_from_memory(&buf) {
             let mut png = std::io::Cursor::new(vec![]);
@@ -288,12 +298,6 @@ impl Docx {
 
             self.images
                 .push((id.into(), path, Image(buf), Png(png.into_inner())));
-        }
-        #[cfg(not(feature = "image"))]
-        // without 'image' crate we can only test for PNG file signature
-        if buf.starts_with(&[137, 80, 78, 71, 13, 10, 26, 10]) {
-            self.images
-                .push((id.into(), path, Image(buf.clone()), Png(buf)));
         }
         self
     }
@@ -1181,14 +1185,27 @@ impl Docx {
     fn images_in_doc(&mut self) -> (Vec<ImageIdAndPath>, Vec<ImageIdAndBuf>) {
         let mut images: Vec<(String, String)> = vec![];
         let mut image_bufs: Vec<(String, Vec<u8>)> = vec![];
+        let mut deduplicator = ImageDeduplicator::default();
 
         for child in &mut self.document.children {
             match child {
                 DocumentChild::Paragraph(paragraph) => {
-                    collect_images_from_paragraph(paragraph, &mut images, &mut image_bufs, None);
+                    collect_images_from_paragraph(
+                        paragraph,
+                        &mut images,
+                        &mut image_bufs,
+                        None,
+                        &mut deduplicator,
+                    );
                 }
                 DocumentChild::Table(table) => {
-                    collect_images_from_table(table, &mut images, &mut image_bufs, None);
+                    collect_images_from_table(
+                        table,
+                        &mut images,
+                        &mut image_bufs,
+                        None,
+                        &mut deduplicator,
+                    );
                 }
                 _ => {}
             }
@@ -1199,6 +1216,7 @@ impl Docx {
     fn images_in_header(&mut self) -> (Vec<Vec<ImageIdAndPath>>, Vec<ImageIdAndBuf>) {
         let mut header_images: Vec<Vec<ImageIdAndPath>> = vec![vec![]; 3];
         let mut image_bufs: Vec<(String, Vec<u8>)> = vec![];
+        let mut deduplicator = ImageDeduplicator::default();
 
         if let Some((_, header)) = &mut self.document.section_property.header.as_mut() {
             let mut images: Vec<ImageIdAndPath> = vec![];
@@ -1210,6 +1228,7 @@ impl Docx {
                             &mut images,
                             &mut image_bufs,
                             Some("header"),
+                            &mut deduplicator,
                         );
                     }
                     HeaderChild::Table(table) => {
@@ -1218,6 +1237,7 @@ impl Docx {
                             &mut images,
                             &mut image_bufs,
                             Some("header"),
+                            &mut deduplicator,
                         );
                     }
                     HeaderChild::StructuredDataTag(tag) => {
@@ -1228,6 +1248,7 @@ impl Docx {
                                     &mut images,
                                     &mut image_bufs,
                                     Some("header"),
+                                    &mut deduplicator,
                                 );
                             }
                             if let StructuredDataTagChild::Table(table) = child {
@@ -1236,6 +1257,7 @@ impl Docx {
                                     &mut images,
                                     &mut image_bufs,
                                     Some("header"),
+                                    &mut deduplicator,
                                 );
                             }
                         }
@@ -1255,6 +1277,7 @@ impl Docx {
                             &mut images,
                             &mut image_bufs,
                             Some("header"),
+                            &mut deduplicator,
                         );
                     }
                     HeaderChild::Table(table) => {
@@ -1263,6 +1286,7 @@ impl Docx {
                             &mut images,
                             &mut image_bufs,
                             Some("header"),
+                            &mut deduplicator,
                         );
                     }
                     HeaderChild::StructuredDataTag(tag) => {
@@ -1273,6 +1297,7 @@ impl Docx {
                                     &mut images,
                                     &mut image_bufs,
                                     Some("header"),
+                                    &mut deduplicator,
                                 );
                             }
                             if let StructuredDataTagChild::Table(table) = child {
@@ -1281,6 +1306,7 @@ impl Docx {
                                     &mut images,
                                     &mut image_bufs,
                                     Some("header"),
+                                    &mut deduplicator,
                                 );
                             }
                         }
@@ -1300,6 +1326,7 @@ impl Docx {
                             &mut images,
                             &mut image_bufs,
                             Some("header"),
+                            &mut deduplicator,
                         );
                     }
                     HeaderChild::Table(table) => {
@@ -1308,6 +1335,7 @@ impl Docx {
                             &mut images,
                             &mut image_bufs,
                             Some("header"),
+                            &mut deduplicator,
                         );
                     }
                     HeaderChild::StructuredDataTag(tag) => {
@@ -1318,6 +1346,7 @@ impl Docx {
                                     &mut images,
                                     &mut image_bufs,
                                     Some("header"),
+                                    &mut deduplicator,
                                 );
                             }
                             if let StructuredDataTagChild::Table(table) = child {
@@ -1326,6 +1355,7 @@ impl Docx {
                                     &mut images,
                                     &mut image_bufs,
                                     Some("header"),
+                                    &mut deduplicator,
                                 );
                             }
                         }
@@ -1341,6 +1371,7 @@ impl Docx {
     fn images_in_footer(&mut self) -> (Vec<Vec<ImageIdAndPath>>, Vec<ImageIdAndBuf>) {
         let mut footer_images: Vec<Vec<ImageIdAndPath>> = vec![vec![]; 3];
         let mut image_bufs: Vec<(String, Vec<u8>)> = vec![];
+        let mut deduplicator = ImageDeduplicator::default();
 
         if let Some((_, footer)) = &mut self.document.section_property.footer.as_mut() {
             let mut images: Vec<ImageIdAndPath> = vec![];
@@ -1352,6 +1383,7 @@ impl Docx {
                             &mut images,
                             &mut image_bufs,
                             Some("footer"),
+                            &mut deduplicator,
                         );
                     }
                     FooterChild::Table(table) => {
@@ -1360,6 +1392,7 @@ impl Docx {
                             &mut images,
                             &mut image_bufs,
                             Some("footer"),
+                            &mut deduplicator,
                         );
                     }
                     FooterChild::StructuredDataTag(tag) => {
@@ -1370,6 +1403,7 @@ impl Docx {
                                     &mut images,
                                     &mut image_bufs,
                                     Some("header"),
+                                    &mut deduplicator,
                                 );
                             }
                             if let StructuredDataTagChild::Table(table) = child {
@@ -1378,6 +1412,7 @@ impl Docx {
                                     &mut images,
                                     &mut image_bufs,
                                     Some("header"),
+                                    &mut deduplicator,
                                 );
                             }
                         }
@@ -1397,6 +1432,7 @@ impl Docx {
                             &mut images,
                             &mut image_bufs,
                             Some("footer"),
+                            &mut deduplicator,
                         );
                     }
                     FooterChild::Table(table) => {
@@ -1405,6 +1441,7 @@ impl Docx {
                             &mut images,
                             &mut image_bufs,
                             Some("footer"),
+                            &mut deduplicator,
                         );
                     }
                     FooterChild::StructuredDataTag(tag) => {
@@ -1415,6 +1452,7 @@ impl Docx {
                                     &mut images,
                                     &mut image_bufs,
                                     Some("header"),
+                                    &mut deduplicator,
                                 );
                             }
                             if let StructuredDataTagChild::Table(table) = child {
@@ -1423,6 +1461,7 @@ impl Docx {
                                     &mut images,
                                     &mut image_bufs,
                                     Some("header"),
+                                    &mut deduplicator,
                                 );
                             }
                         }
@@ -1442,6 +1481,7 @@ impl Docx {
                             &mut images,
                             &mut image_bufs,
                             Some("footer"),
+                            &mut deduplicator,
                         );
                     }
                     FooterChild::Table(table) => {
@@ -1450,6 +1490,7 @@ impl Docx {
                             &mut images,
                             &mut image_bufs,
                             Some("footer"),
+                            &mut deduplicator,
                         );
                     }
                     FooterChild::StructuredDataTag(tag) => {
@@ -1460,6 +1501,7 @@ impl Docx {
                                     &mut images,
                                     &mut image_bufs,
                                     Some("header"),
+                                    &mut deduplicator,
                                 );
                             }
                             if let StructuredDataTagChild::Table(table) = child {
@@ -1468,6 +1510,7 @@ impl Docx {
                                     &mut images,
                                     &mut image_bufs,
                                     Some("header"),
+                                    &mut deduplicator,
                                 );
                             }
                         }
@@ -2594,21 +2637,14 @@ mod emf_tests {
 
     #[test]
     fn add_image_routes_png_as_png_preview() {
-        // Smallest valid 1x1 RGB PNG, generated via the `image` crate.
-        let png_bytes = {
-            let img = image::RgbImage::from_pixel(1, 1, image::Rgb([0, 0, 0]));
-            let mut cursor = std::io::Cursor::new(Vec::new());
-            image::DynamicImage::ImageRgb8(img)
-                .write_to(&mut cursor, image::ImageFormat::Png)
-                .unwrap();
-            cursor.into_inner()
-        };
-        let _ = png_signature_bytes(); // suppress unused warning if any
-        let docx = Docx::new().add_image("rId1", "word/media/image1.png", png_bytes);
+        let png_bytes = png_signature_bytes();
+        let docx = Docx::new().add_image("rId1", "word/media/image1.png", png_bytes.clone());
         assert_eq!(docx.images.len(), 1);
-        let (_, _, _, preview) = &docx.images[0];
+        let (_, _, original, preview) = &docx.images[0];
         // PNG preview starts with the PNG signature, not `<svg`.
         assert_eq!(&preview.0[..8], &[137, 80, 78, 71, 13, 10, 26, 10]);
+        assert_eq!(original.0, png_bytes);
+        assert_eq!(preview.0, png_bytes);
     }
 
     // ---------- Docx JSON serialization ----------

--- a/docx-core/src/documents/mod.rs
+++ b/docx-core/src/documents/mod.rs
@@ -270,14 +270,31 @@ impl Docx {
 
     // reader only
     pub(crate) fn add_image(
-        mut self,
+        self,
         id: impl Into<String>,
         path: impl Into<String>,
         buf: Vec<u8>,
     ) -> Self {
+        self.add_image_with_options(id, path, buf, true)
+    }
+
+    // reader only
+    pub(crate) fn add_image_with_options(
+        mut self,
+        id: impl Into<String>,
+        path: impl Into<String>,
+        buf: Vec<u8>,
+        generate_preview: bool,
+    ) -> Self {
         let path: String = path.into();
 
         if is_emf(&path, &buf) {
+            self.images
+                .push((id.into(), path, Image(buf), Png(Vec::new())));
+            return self;
+        }
+
+        if !generate_preview {
             self.images
                 .push((id.into(), path, Image(buf), Png(Vec::new())));
             return self;

--- a/docx-core/src/escape/mod.rs
+++ b/docx-core/src/escape/mod.rs
@@ -1,21 +1,68 @@
 pub(crate) fn escape(text: &str) -> String {
-    text.replace('&', "&amp;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
-        .replace('"', "&quot;")
-        .replace('\'', "&apos;")
-        .replace('\n', "&#xA;")
-        // If \r escape to &#xD, this cause error in libreoffice
-        // .replace('\r', "&#xD;")
-        .replace('\r', "")
+    let mut escaped = String::with_capacity(text.len());
+    for ch in text.chars() {
+        match ch {
+            '&' => escaped.push_str("&amp;"),
+            '<' => escaped.push_str("&lt;"),
+            '>' => escaped.push_str("&gt;"),
+            '"' => escaped.push_str("&quot;"),
+            '\'' => escaped.push_str("&apos;"),
+            '\n' => escaped.push_str("&#xA;"),
+            // Escaping carriage returns causes errors in LibreOffice.
+            '\r' => {}
+            _ => escaped.push(ch),
+        }
+    }
+    escaped
 }
 
 pub(crate) fn replace_escaped(text: &str) -> String {
-    text.replace("&lt;", "<")
-        .replace("&gt;", ">")
-        .replace("&amp;", "&")
-        .replace("&quot;", "\"")
-        .replace("&#39;", "'")
-        .replace("&apos;", "'")
-        .replace("&nbsp;", " ")
+    let mut decoded = String::with_capacity(text.len());
+    let mut rest = text;
+
+    while let Some(index) = rest.find('&') {
+        decoded.push_str(&rest[..index]);
+        rest = &rest[index..];
+        let (replacement, consumed) = if rest.starts_with("&lt;") {
+            (Some("<"), 4)
+        } else if rest.starts_with("&gt;") {
+            (Some(">"), 4)
+        } else if rest.starts_with("&amp;") {
+            (Some("&"), 5)
+        } else if rest.starts_with("&quot;") {
+            (Some("\""), 6)
+        } else if rest.starts_with("&#39;") {
+            (Some("'"), 5)
+        } else if rest.starts_with("&apos;") {
+            (Some("'"), 6)
+        } else if rest.starts_with("&nbsp;") {
+            (Some(" "), 6)
+        } else {
+            (None, 1)
+        };
+        decoded.push_str(replacement.unwrap_or("&"));
+        rest = &rest[consumed..];
+    }
+    decoded.push_str(rest);
+    decoded
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn escapes_all_supported_characters_in_one_pass() {
+        assert_eq!(
+            escape("<&>\"'\n\rplain"),
+            "&lt;&amp;&gt;&quot;&apos;&#xA;plain"
+        );
+    }
+
+    #[test]
+    fn replaces_entities_without_recursively_decoding_them() {
+        assert_eq!(replace_escaped("&lt;&amp;&apos;&nbsp;"), "<&' ");
+        assert_eq!(replace_escaped("&amp;lt;"), "&lt;");
+        assert_eq!(replace_escaped("plain &unknown;"), "plain &unknown;");
+    }
 }

--- a/docx-core/src/reader/document_rels.rs
+++ b/docx-core/src/reader/document_rels.rs
@@ -22,6 +22,13 @@ impl ReadDocumentRels {
             .get(target)
             .map(|s| s.clone().into_iter().collect())
     }
+
+    pub(crate) fn target_paths(
+        &self,
+        target: &str,
+    ) -> Option<&BTreeSet<(RId, PathBuf, Option<String>)>> {
+        self.rels.get(target)
+    }
 }
 
 pub fn read_document_rels(

--- a/docx-core/src/reader/header_or_footer_rels.rs
+++ b/docx-core/src/reader/header_or_footer_rels.rs
@@ -18,10 +18,18 @@ pub struct ReadHeaderOrFooterRels {
 }
 
 impl ReadHeaderOrFooterRels {
+    #[allow(dead_code)]
     pub fn find_target_path(&self, target: &str) -> Option<Vec<(RId, PathBuf, Option<String>)>> {
         self.rels
             .get(target)
             .map(|s| s.clone().into_iter().collect())
+    }
+
+    pub(crate) fn target_paths(
+        &self,
+        target: &str,
+    ) -> Option<&BTreeSet<(RId, PathBuf, Option<String>)>> {
+        self.rels.get(target)
     }
 }
 

--- a/docx-core/src/reader/read_docx.rs
+++ b/docx-core/src/reader/read_docx.rs
@@ -8,16 +8,16 @@ fn read_headers(
     rels: &ReadDocumentRels,
     archive: &mut ZipArchive<Cursor<&[u8]>>,
 ) -> HashMap<RId, (Header, ReadHeaderOrFooterRels)> {
-    let header_paths = rels.find_target_path(HEADER_TYPE);
+    let header_paths = rels.target_paths(HEADER_TYPE);
     let headers: HashMap<RId, (Header, ReadHeaderOrFooterRels)> = header_paths
-        .unwrap_or_default()
         .into_iter()
+        .flatten()
         .filter_map(|(rid, path, ..)| {
             let data = read_zip(archive, path.to_str().expect("should have header path."));
             if let Ok(d) = data {
                 if let Ok(h) = Header::from_xml(&d[..]) {
                     let rels = read_header_or_footer_rels(archive, path).unwrap_or_default();
-                    return Some((rid, (h, rels)));
+                    return Some((rid.clone(), (h, rels)));
                 }
             }
             None
@@ -30,16 +30,16 @@ fn read_footers(
     rels: &ReadDocumentRels,
     archive: &mut ZipArchive<Cursor<&[u8]>>,
 ) -> HashMap<RId, (Footer, ReadHeaderOrFooterRels)> {
-    let footer_paths = rels.find_target_path(FOOTER_TYPE);
+    let footer_paths = rels.target_paths(FOOTER_TYPE);
     let footers: HashMap<RId, (Footer, ReadHeaderOrFooterRels)> = footer_paths
-        .unwrap_or_default()
         .into_iter()
+        .flatten()
         .filter_map(|(rid, path, ..)| {
             let data = read_zip(archive, path.to_str().expect("should have footer path."));
             if let Ok(d) = data {
                 if let Ok(h) = Footer::from_xml(&d[..]) {
                     let rels = read_header_or_footer_rels(archive, path).unwrap_or_default();
-                    return Some((rid, (h, rels)));
+                    return Some((rid.clone(), (h, rels)));
                 }
             }
             None
@@ -49,10 +49,10 @@ fn read_footers(
 }
 
 fn read_themes(rels: &ReadDocumentRels, archive: &mut ZipArchive<Cursor<&[u8]>>) -> Vec<Theme> {
-    let theme_paths = rels.find_target_path(THEME_TYPE);
+    let theme_paths = rels.target_paths(THEME_TYPE);
     theme_paths
-        .unwrap_or_default()
         .into_iter()
+        .flatten()
         .filter_map(|(_rid, path, ..)| {
             let data = read_zip(archive, path.to_str().expect("should have footer path."));
             if let Ok(d) = data {
@@ -112,7 +112,7 @@ pub fn read_docx(buf: &[u8]) -> Result<Docx, ReaderError> {
     docx.themes = read_themes(&rels, &mut archive);
 
     // Read commentsExtended
-    let comments_extended_path = rels.find_target_path(COMMENTS_EXTENDED_TYPE);
+    let comments_extended_path = rels.target_paths(COMMENTS_EXTENDED_TYPE);
     let comments_extended = if let Some(comments_extended_path) = comments_extended_path {
         if let Some((_, comments_extended_path, ..)) = comments_extended_path.first() {
             let data = read_zip(
@@ -134,7 +134,7 @@ pub fn read_docx(buf: &[u8]) -> Result<Docx, ReaderError> {
     };
 
     // Read comments
-    let comments_path = rels.find_target_path(COMMENTS_TYPE);
+    let comments_path = rels.target_paths(COMMENTS_TYPE);
     let comments = if let Some(paths) = comments_path {
         if let Some((_, comments_path, ..)) = paths.first() {
             let data = read_zip(
@@ -206,7 +206,7 @@ pub fn read_docx(buf: &[u8]) -> Result<Docx, ReaderError> {
             docx.document_rels.header_count = count;
             docx.content_type = docx.content_type.add_header();
             // Read media
-            let media = rels.find_target_path(IMAGE_TYPE);
+            let media = rels.target_paths(IMAGE_TYPE);
             docx = add_images(docx, media, &mut archive);
         }
     }
@@ -224,7 +224,7 @@ pub fn read_docx(buf: &[u8]) -> Result<Docx, ReaderError> {
             docx.document_rels.header_count = count;
             docx.content_type = docx.content_type.add_header();
             // Read media
-            let media = rels.find_target_path(IMAGE_TYPE);
+            let media = rels.target_paths(IMAGE_TYPE);
             docx = add_images(docx, media, &mut archive);
         }
     }
@@ -236,7 +236,7 @@ pub fn read_docx(buf: &[u8]) -> Result<Docx, ReaderError> {
             docx.content_type = docx.content_type.add_header();
 
             // Read media
-            let media = rels.find_target_path(IMAGE_TYPE);
+            let media = rels.target_paths(IMAGE_TYPE);
             docx = add_images(docx, media, &mut archive);
         }
     }
@@ -250,7 +250,7 @@ pub fn read_docx(buf: &[u8]) -> Result<Docx, ReaderError> {
             docx.content_type = docx.content_type.add_footer();
 
             // Read media
-            let media = rels.find_target_path(IMAGE_TYPE);
+            let media = rels.target_paths(IMAGE_TYPE);
             docx = add_images(docx, media, &mut archive);
         }
     }
@@ -270,7 +270,7 @@ pub fn read_docx(buf: &[u8]) -> Result<Docx, ReaderError> {
             docx.content_type = docx.content_type.add_footer();
 
             // Read media
-            let media = rels.find_target_path(IMAGE_TYPE);
+            let media = rels.target_paths(IMAGE_TYPE);
             docx = add_images(docx, media, &mut archive);
         }
     }
@@ -282,7 +282,7 @@ pub fn read_docx(buf: &[u8]) -> Result<Docx, ReaderError> {
             docx.content_type = docx.content_type.add_footer();
 
             // Read media
-            let media = rels.find_target_path(IMAGE_TYPE);
+            let media = rels.target_paths(IMAGE_TYPE);
             docx = add_images(docx, media, &mut archive);
         }
     }
@@ -296,7 +296,7 @@ pub fn read_docx(buf: &[u8]) -> Result<Docx, ReaderError> {
 
     // Read document relationships
     // Read styles
-    let style_path = rels.find_target_path(STYLE_RELATIONSHIP_TYPE);
+    let style_path = rels.target_paths(STYLE_RELATIONSHIP_TYPE);
     if let Some(paths) = style_path {
         if let Some((_, style_path, ..)) = paths.first() {
             let data = read_zip(
@@ -309,7 +309,7 @@ pub fn read_docx(buf: &[u8]) -> Result<Docx, ReaderError> {
     }
 
     // Read numberings
-    let num_path = rels.find_target_path(NUMBERING_RELATIONSHIP_TYPE);
+    let num_path = rels.target_paths(NUMBERING_RELATIONSHIP_TYPE);
     if let Some(paths) = num_path {
         if let Some((_, num_path, ..)) = paths.first() {
             let data = read_zip(
@@ -322,7 +322,7 @@ pub fn read_docx(buf: &[u8]) -> Result<Docx, ReaderError> {
     }
 
     // Read settings
-    let settings_path = rels.find_target_path(SETTINGS_TYPE);
+    let settings_path = rels.target_paths(SETTINGS_TYPE);
     if let Some(paths) = settings_path {
         if let Some((_, settings_path, ..)) = paths.first() {
             let data = read_zip(
@@ -335,7 +335,7 @@ pub fn read_docx(buf: &[u8]) -> Result<Docx, ReaderError> {
     }
 
     // Read web settings
-    let web_settings_path = rels.find_target_path(WEB_SETTINGS_TYPE);
+    let web_settings_path = rels.target_paths(WEB_SETTINGS_TYPE);
     if let Some(paths) = web_settings_path {
         if let Some((_, web_settings_path, ..)) = paths.first() {
             let data = read_zip(
@@ -349,16 +349,19 @@ pub fn read_docx(buf: &[u8]) -> Result<Docx, ReaderError> {
         }
     }
     // Read media
-    let media = rels.find_target_path(IMAGE_TYPE);
+    let media = rels.target_paths(IMAGE_TYPE);
     docx = add_images(docx, media, &mut archive);
 
     // Read hyperlinks
-    let links = rels.find_target_path(HYPERLINK_TYPE);
+    let links = rels.target_paths(HYPERLINK_TYPE);
     if let Some(paths) = links {
         for (id, target, mode) in paths {
             if let Some(mode) = mode {
-                docx =
-                    docx.add_hyperlink(id, target.to_str().expect("should convert to str"), mode);
+                docx = docx.add_hyperlink(
+                    id.clone(),
+                    target.to_str().expect("should convert to str"),
+                    mode.clone(),
+                );
             }
         }
     }
@@ -368,14 +371,14 @@ pub fn read_docx(buf: &[u8]) -> Result<Docx, ReaderError> {
 
 fn add_images(
     mut docx: Docx,
-    media: Option<Vec<(RId, PathBuf, Option<String>)>>,
+    media: Option<&std::collections::BTreeSet<(RId, PathBuf, Option<String>)>>,
     archive: &mut ZipArchive<Cursor<&[u8]>>,
 ) -> Docx {
     // Read media
     if let Some(paths) = media {
         for (id, media, ..) in paths {
             if let Ok(data) = read_zip(archive, media.to_str().expect("should have media")) {
-                docx = docx.add_image(id, media.to_str().unwrap().to_string(), data);
+                docx = docx.add_image(id.clone(), media.to_str().unwrap().to_string(), data);
             }
         }
     }

--- a/docx-core/src/reader/read_docx.rs
+++ b/docx-core/src/reader/read_docx.rs
@@ -65,7 +65,38 @@ fn read_themes(rels: &ReadDocumentRels, archive: &mut ZipArchive<Cursor<&[u8]>>)
         .collect()
 }
 
+/// Controls optional work performed while reading a DOCX package.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub struct ReadDocxOptions {
+    /// Generate PNG previews for embedded images.
+    ///
+    /// Disabling this avoids decoding and re-encoding non-PNG images. The original
+    /// image bytes are still available in [`Docx::images`], while the preview is empty.
+    pub generate_image_previews: bool,
+}
+
+impl ReadDocxOptions {
+    /// Enables or disables PNG preview generation for embedded images.
+    pub const fn with_image_previews(mut self, generate: bool) -> Self {
+        self.generate_image_previews = generate;
+        self
+    }
+}
+
+impl Default for ReadDocxOptions {
+    fn default() -> Self {
+        Self {
+            generate_image_previews: true,
+        }
+    }
+}
+
 pub fn read_docx(buf: &[u8]) -> Result<Docx, ReaderError> {
+    read_docx_with_options(buf, ReadDocxOptions::default())
+}
+
+pub fn read_docx_with_options(buf: &[u8], options: ReadDocxOptions) -> Result<Docx, ReaderError> {
     let mut docx = Docx::new();
     let cur = Cursor::new(buf);
     let mut archive = zip::ZipArchive::new(cur)?;
@@ -207,7 +238,7 @@ pub fn read_docx(buf: &[u8]) -> Result<Docx, ReaderError> {
             docx.content_type = docx.content_type.add_header();
             // Read media
             let media = rels.target_paths(IMAGE_TYPE);
-            docx = add_images(docx, media, &mut archive);
+            docx = add_images(docx, media, &mut archive, options.generate_image_previews);
         }
     }
     if let Some(ref h) = docx
@@ -225,7 +256,7 @@ pub fn read_docx(buf: &[u8]) -> Result<Docx, ReaderError> {
             docx.content_type = docx.content_type.add_header();
             // Read media
             let media = rels.target_paths(IMAGE_TYPE);
-            docx = add_images(docx, media, &mut archive);
+            docx = add_images(docx, media, &mut archive, options.generate_image_previews);
         }
     }
     if let Some(ref h) = docx.document.section_property.even_header_reference.clone() {
@@ -237,7 +268,7 @@ pub fn read_docx(buf: &[u8]) -> Result<Docx, ReaderError> {
 
             // Read media
             let media = rels.target_paths(IMAGE_TYPE);
-            docx = add_images(docx, media, &mut archive);
+            docx = add_images(docx, media, &mut archive, options.generate_image_previews);
         }
     }
 
@@ -251,7 +282,7 @@ pub fn read_docx(buf: &[u8]) -> Result<Docx, ReaderError> {
 
             // Read media
             let media = rels.target_paths(IMAGE_TYPE);
-            docx = add_images(docx, media, &mut archive);
+            docx = add_images(docx, media, &mut archive, options.generate_image_previews);
         }
     }
 
@@ -271,7 +302,7 @@ pub fn read_docx(buf: &[u8]) -> Result<Docx, ReaderError> {
 
             // Read media
             let media = rels.target_paths(IMAGE_TYPE);
-            docx = add_images(docx, media, &mut archive);
+            docx = add_images(docx, media, &mut archive, options.generate_image_previews);
         }
     }
     if let Some(ref f) = docx.document.section_property.even_footer_reference.clone() {
@@ -283,7 +314,7 @@ pub fn read_docx(buf: &[u8]) -> Result<Docx, ReaderError> {
 
             // Read media
             let media = rels.target_paths(IMAGE_TYPE);
-            docx = add_images(docx, media, &mut archive);
+            docx = add_images(docx, media, &mut archive, options.generate_image_previews);
         }
     }
 
@@ -350,7 +381,7 @@ pub fn read_docx(buf: &[u8]) -> Result<Docx, ReaderError> {
     }
     // Read media
     let media = rels.target_paths(IMAGE_TYPE);
-    docx = add_images(docx, media, &mut archive);
+    docx = add_images(docx, media, &mut archive, options.generate_image_previews);
 
     // Read hyperlinks
     let links = rels.target_paths(HYPERLINK_TYPE);
@@ -373,14 +404,51 @@ fn add_images(
     mut docx: Docx,
     media: Option<&std::collections::BTreeSet<(RId, PathBuf, Option<String>)>>,
     archive: &mut ZipArchive<Cursor<&[u8]>>,
+    generate_previews: bool,
 ) -> Docx {
     // Read media
     if let Some(paths) = media {
         for (id, media, ..) in paths {
             if let Ok(data) = read_zip(archive, media.to_str().expect("should have media")) {
-                docx = docx.add_image(id.clone(), media.to_str().unwrap().to_string(), data);
+                docx = docx.add_image_with_options(
+                    id.clone(),
+                    media.to_str().unwrap().to_string(),
+                    data,
+                    generate_previews,
+                );
             }
         }
     }
     docx
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    static JPEG_DOCX: &[u8] = include_bytes!("../../../fixtures/image_output/image.docx");
+
+    #[test]
+    fn read_without_image_previews_preserves_original_image() {
+        let docx = read_docx_with_options(
+            JPEG_DOCX,
+            ReadDocxOptions::default().with_image_previews(false),
+        )
+        .unwrap();
+
+        assert_eq!(docx.images.len(), 1);
+        let (_, _, image, preview) = &docx.images[0];
+        assert!(!image.0.is_empty());
+        assert!(preview.0.is_empty());
+    }
+
+    #[cfg(feature = "image")]
+    #[test]
+    fn read_with_default_options_generates_image_preview() {
+        let docx = read_docx(JPEG_DOCX).unwrap();
+
+        assert_eq!(docx.images.len(), 1);
+        let (_, _, _, preview) = &docx.images[0];
+        assert!(!preview.0.is_empty());
+    }
 }

--- a/docx-core/src/reader/read_zip.rs
+++ b/docx-core/src/reader/read_zip.rs
@@ -6,20 +6,22 @@ pub fn read_zip(
     archive: &mut zip::read::ZipArchive<Cursor<&[u8]>>,
     name: &str,
 ) -> Result<Vec<u8>, ReaderError> {
-    let p = name.to_owned();
     // Archives zipped on Windows keep '\' in paths, replace them to avoid zip error.
-    let mut p = str::replace(&p, "\\", "/");
-    if p.starts_with('/') {
-        p.remove(0);
-    }
-    let mut xml = archive.by_name(&p)?;
-    let mut data = vec![];
+    let normalized;
+    let path = if name.contains('\\') {
+        normalized = name.replace('\\', "/");
+        normalized.trim_start_matches('/')
+    } else {
+        name.trim_start_matches('/')
+    };
+    let mut xml = archive.by_name(path)?;
+    let capacity = usize::try_from(xml.size()).unwrap_or(0);
+    let mut data = Vec::with_capacity(capacity);
     xml.read_to_end(&mut data).unwrap();
     // Remove BOM
-    if (data[0] == 0xef) && (data[1] == 0xbb) && (data[2] == 0xbf) {
-        data.remove(0);
-        data.remove(0);
-        data.remove(0);
+    if data.starts_with(&[0xef, 0xbb, 0xbf]) {
+        data.copy_within(3.., 0);
+        data.truncate(data.len() - 3);
     }
     Ok(data)
 }

--- a/docx-core/src/reader/rels.rs
+++ b/docx-core/src/reader/rels.rs
@@ -96,15 +96,9 @@ pub fn read_rels_xml<R: Read>(reader: R, dir: impl AsRef<Path>) -> Result<ReadRe
                         Path::new("").join(target_string)
                     };
 
-                    let current = rels.remove(&rel_type);
-                    if let Some(mut paths) = current {
-                        paths.insert((rid, target, target_mode));
-                        rels.insert(rel_type, paths);
-                    } else {
-                        let s: BTreeSet<(RId, PathBuf, Option<String>)> =
-                            vec![(rid, target, target_mode)].into_iter().collect();
-                        rels.insert(rel_type, s);
-                    }
+                    rels.entry(rel_type)
+                        .or_default()
+                        .insert((rid, target, target_mode));
                     continue;
                 }
             }

--- a/docx-core/src/reader/xml_parser.rs
+++ b/docx-core/src/reader/xml_parser.rs
@@ -184,7 +184,11 @@ impl<R: Read> EventReader<R> {
             }
         }
 
-        if text.chars().all(char::is_whitespace) {
+        if text
+            .as_bytes()
+            .iter()
+            .all(|byte| matches!(byte, b' ' | b'\t' | b'\n' | b'\r'))
+        {
             Ok(XmlEvent::Whitespace(text))
         } else {
             Ok(XmlEvent::Characters(text))
@@ -241,16 +245,26 @@ fn decode_text(text: BytesText<'_>) -> Result<String, quick_xml::Error> {
 }
 
 fn decode_reference(reference: BytesRef<'_>) -> Result<String, quick_xml::Error> {
+    if let Some(ch) = reference.resolve_char_ref()? {
+        return Ok(ch.to_string());
+    }
     let reference = reference.xml_content(XmlVersion::Implicit1_0)?;
+    match reference.as_ref() {
+        "lt" => return Ok("<".to_owned()),
+        "gt" => return Ok(">".to_owned()),
+        "amp" => return Ok("&".to_owned()),
+        "apos" => return Ok("'".to_owned()),
+        "quot" => return Ok("\"".to_owned()),
+        _ => {}
+    }
     let escaped = format!("&{reference};");
     Ok(unescape(&escaped)?.into_owned())
 }
 
 fn split_qname(raw: &[u8]) -> OwnedName {
-    let text = String::from_utf8_lossy(raw).into_owned();
-    if let Some(idx) = text.find(':') {
-        let prefix = text[..idx].to_string();
-        let local = text[idx + 1..].to_string();
+    if let Some(idx) = raw.iter().position(|byte| *byte == b':') {
+        let prefix = String::from_utf8_lossy(&raw[..idx]).into_owned();
+        let local = String::from_utf8_lossy(&raw[idx + 1..]).into_owned();
         OwnedName {
             local_name: local,
             namespace: None,
@@ -258,7 +272,7 @@ fn split_qname(raw: &[u8]) -> OwnedName {
         }
     } else {
         OwnedName {
-            local_name: text,
+            local_name: String::from_utf8_lossy(raw).into_owned(),
             namespace: None,
             prefix: None,
         }
@@ -269,8 +283,10 @@ fn build_attributes(
     element: &BytesStart<'_>,
     decoder: Decoder,
 ) -> Result<Vec<OwnedAttribute>, quick_xml::Error> {
-    let mut attributes = Vec::new();
-    for attr_result in element.attributes().with_checks(false) {
+    let mut raw_attributes = element.attributes();
+    let iter = raw_attributes.with_checks(false);
+    let mut attributes = Vec::with_capacity(iter.size_hint().0);
+    for attr_result in iter {
         let attr = attr_result.map_err(quick_xml::Error::from)?;
         let value = attr
             .decoded_and_normalized_value(XmlVersion::Implicit1_0, decoder)?

--- a/docx-core/src/xml/writer.rs
+++ b/docx-core/src/xml/writer.rs
@@ -239,4 +239,26 @@ impl<'a> StartElement<'a> {
         self.encoded.push(b'"');
         self
     }
+
+    pub fn attr_display(mut self, name: &str, value: impl fmt::Display) -> Self {
+        self.encoded.push(b' ');
+        self.encoded.extend_from_slice(name.as_bytes());
+        self.encoded.extend_from_slice(b"=\"");
+        fmt::write(
+            &mut AttributeValueWriter(&mut self.encoded),
+            format_args!("{value}"),
+        )
+        .expect("writing to an in-memory attribute buffer cannot fail");
+        self.encoded.push(b'"');
+        self
+    }
+}
+
+struct AttributeValueWriter<'a>(&'a mut SmallVec<[u8; 128]>);
+
+impl fmt::Write for AttributeValueWriter<'_> {
+    fn write_str(&mut self, value: &str) -> fmt::Result {
+        self.0.extend_from_slice(value.as_bytes());
+        Ok(())
+    }
 }

--- a/docx-core/src/xml/writer.rs
+++ b/docx-core/src/xml/writer.rs
@@ -5,6 +5,7 @@ use std::marker::PhantomData;
 
 use quick_xml::events::{BytesDecl, BytesText, Event};
 use quick_xml::Writer as QuickWriter;
+use smallvec::SmallVec;
 
 use super::common::XmlVersion;
 
@@ -74,14 +75,16 @@ impl EmitterConfig {
             writer: QuickWriter::new(writer),
             perform_escaping: self.perform_escaping,
             element_stack: Vec::new(),
+            element_names: Vec::new(),
+            pending_start: SmallVec::new(),
         }
     }
 }
 
 #[derive(Debug)]
 struct ElementState {
-    name: String,
-    attributes: Vec<Attribute>,
+    name_start: usize,
+    name_len: usize,
     pending: bool,
 }
 
@@ -89,6 +92,8 @@ pub struct EventWriter<W: Write> {
     writer: QuickWriter<W>,
     perform_escaping: bool,
     element_stack: Vec<ElementState>,
+    element_names: Vec<u8>,
+    pending_start: SmallVec<[u8; 128]>,
 }
 
 impl<W: Write> EventWriter<W> {
@@ -108,22 +113,33 @@ impl<W: Write> EventWriter<W> {
             }
             XmlEvent::StartElement(element) => {
                 self.flush_pending()?;
-                let StartElement {
-                    name, attributes, ..
-                } = element;
+                let name = &element.encoded[1..1 + element.name_len];
+                let name_start = self.element_names.len();
+                self.element_names.extend_from_slice(name);
                 self.element_stack.push(ElementState {
-                    name,
-                    attributes,
+                    name_start,
+                    name_len: element.name_len,
                     pending: true,
                 });
+                self.pending_start = element.encoded;
             }
             XmlEvent::EndElement => {
                 let state = self.element_stack.pop().ok_or(Error::UnbalancedEndTag)?;
                 if state.pending {
-                    self.write_empty(state)?;
+                    let writer = self.writer.get_mut();
+                    writer.write_all(&self.pending_start).map_err(Error::from)?;
+                    writer.write_all(b" />").map_err(Error::from)?;
+                    self.pending_start.clear();
                 } else {
-                    self.write_closing(&state.name)?;
+                    let name_end = state.name_start + state.name_len;
+                    let writer = self.writer.get_mut();
+                    writer.write_all(b"</").map_err(Error::from)?;
+                    writer
+                        .write_all(&self.element_names[state.name_start..name_end])
+                        .map_err(Error::from)?;
+                    writer.write_all(b">").map_err(Error::from)?;
                 }
+                self.element_names.truncate(state.name_start);
             }
             XmlEvent::Characters(text) => {
                 self.flush_pending()?;
@@ -151,68 +167,20 @@ impl<W: Write> EventWriter<W> {
             if state.pending {
                 state.pending = false;
                 let writer = self.writer.get_mut();
-                writer.write_all(b"<").map_err(Error::from)?;
-                writer
-                    .write_all(state.name.as_bytes())
-                    .map_err(Error::from)?;
-                for attr in &state.attributes {
-                    writer.write_all(b" ").map_err(Error::from)?;
-                    writer
-                        .write_all(attr.name.as_bytes())
-                        .map_err(Error::from)?;
-                    writer.write_all(b"=\"").map_err(Error::from)?;
-                    writer
-                        .write_all(attr.value.as_bytes())
-                        .map_err(Error::from)?;
-                    writer.write_all(b"\"").map_err(Error::from)?;
-                }
+                writer.write_all(&self.pending_start).map_err(Error::from)?;
                 writer.write_all(b">").map_err(Error::from)?;
+                self.pending_start.clear();
             }
         }
         Ok(())
-    }
-
-    fn write_empty(&mut self, state: ElementState) -> Result<()> {
-        self.write_tag(state.name.as_str(), &state.attributes, b" />")
-    }
-
-    fn write_closing(&mut self, name: &str) -> Result<()> {
-        let writer = self.writer.get_mut();
-        writer.write_all(b"</").map_err(Error::from)?;
-        writer.write_all(name.as_bytes()).map_err(Error::from)?;
-        writer.write_all(b">").map_err(Error::from)
-    }
-
-    fn write_tag(&mut self, name: &str, attributes: &[Attribute], suffix: &[u8]) -> Result<()> {
-        let writer = self.writer.get_mut();
-        writer.write_all(b"<").map_err(Error::from)?;
-        writer.write_all(name.as_bytes()).map_err(Error::from)?;
-        for attr in attributes {
-            writer.write_all(b" ").map_err(Error::from)?;
-            writer
-                .write_all(attr.name.as_bytes())
-                .map_err(Error::from)?;
-            writer.write_all(b"=\"").map_err(Error::from)?;
-            writer
-                .write_all(attr.value.as_bytes())
-                .map_err(Error::from)?;
-            writer.write_all(b"\"").map_err(Error::from)?;
-        }
-        writer.write_all(suffix).map_err(Error::from)
     }
 }
 
 #[derive(Clone, Debug)]
 pub struct StartElement<'a> {
-    name: String,
-    attributes: Vec<Attribute>,
+    encoded: SmallVec<[u8; 128]>,
+    name_len: usize,
     _marker: PhantomData<&'a ()>,
-}
-
-#[derive(Clone, Debug)]
-struct Attribute {
-    name: String,
-    value: String,
 }
 
 #[derive(Clone, Debug)]
@@ -229,9 +197,12 @@ pub enum XmlEvent<'a> {
 
 impl<'a> XmlEvent<'a> {
     pub fn start_element(name: &'a str) -> StartElement<'a> {
+        let mut encoded = SmallVec::new();
+        encoded.push(b'<');
+        encoded.extend_from_slice(name.as_bytes());
         StartElement {
-            name: name.to_string(),
-            attributes: Vec::new(),
+            encoded,
+            name_len: name.len(),
             _marker: std::marker::PhantomData,
         }
     }
@@ -261,10 +232,11 @@ impl From<String> for XmlEvent<'static> {
 
 impl<'a> StartElement<'a> {
     pub fn attr(mut self, name: &str, value: &str) -> Self {
-        self.attributes.push(Attribute {
-            name: name.to_string(),
-            value: value.to_string(),
-        });
+        self.encoded.push(b' ');
+        self.encoded.extend_from_slice(name.as_bytes());
+        self.encoded.extend_from_slice(b"=\"");
+        self.encoded.extend_from_slice(value.as_bytes());
+        self.encoded.push(b'"');
         self
     }
 }

--- a/docx-core/src/xml_builder/elements.rs
+++ b/docx-core/src/xml_builder/elements.rs
@@ -281,24 +281,19 @@ impl<W: Write> XMLBuilder<W> {
         end: i32,
         start_chars: Option<i32>,
     ) -> Result<Self> {
-        let start = &format!("{}", start.unwrap_or(0));
-        let end = &format!("{end}");
-        let start_chars_value = format!("{}", start_chars.unwrap_or(0));
         let mut base = XmlEvent::start_element("w:ind")
-            .attr("w:left", start)
-            .attr("w:right", end);
+            .attr_display("w:left", start.unwrap_or(0))
+            .attr_display("w:right", end);
 
-        if start_chars.is_some() {
-            base = base.attr("w:leftChars", &start_chars_value);
+        if let Some(start_chars) = start_chars {
+            base = base.attr_display("w:leftChars", start_chars);
         }
 
         match special_indent {
             Some(SpecialIndentType::FirstLine(v)) => {
-                self.write(base.attr("w:firstLine", &format!("{v}")))
+                self.write(base.attr_display("w:firstLine", v))
             }
-            Some(SpecialIndentType::Hanging(v)) => {
-                self.write(base.attr("w:hanging", &format!("{v}")))
-            }
+            Some(SpecialIndentType::Hanging(v)) => self.write(base.attr_display("w:hanging", v)),
             None => self.write(base),
         }?
         .close()
@@ -306,23 +301,21 @@ impl<W: Write> XMLBuilder<W> {
 
     // i.e. <w:spacing ... >
     pub(crate) fn spacing(self, s: i32) -> Result<Self> {
-        self.write(XmlEvent::start_element("w:spacing").attr("w:val", &format!("{s}")))?
+        self.write(XmlEvent::start_element("w:spacing").attr_display("w:val", s))?
             .close()
     }
 
     // i.e. <w:w ... >
     pub(crate) fn w(self, s: i32) -> Result<Self> {
-        self.write(XmlEvent::start_element("w:w").attr("w:val", &format!("{s}")))?
+        self.write(XmlEvent::start_element("w:w").attr_display("w:val", s))?
             .close()
     }
 
     // i.e. <w:fitText ... >
     pub(crate) fn fit_text(self, val: usize, id: Option<u32>) -> Result<Self> {
-        let mut fit_text = XmlEvent::start_element("w:fitText").attr("w:val", &format!("{val}"));
-        let id_value;
+        let mut fit_text = XmlEvent::start_element("w:fitText").attr_display("w:val", val);
         if let Some(id) = id {
-            id_value = format!("{id}");
-            fit_text = fit_text.attr("w:id", &id_value);
+            fit_text = fit_text.attr_display("w:id", id);
         }
         self.write(fit_text)?.close()
     }
@@ -338,31 +331,20 @@ impl<W: Write> XMLBuilder<W> {
         spacing: Option<LineSpacingType>,
     ) -> Result<Self> {
         let mut xml_event = XmlEvent::start_element("w:spacing");
-        let before_val: String;
-        let after_val: String;
-        let before_lines_val: String;
-        let after_lines_val: String;
-        let line_val: String;
-
         if let Some(before) = before {
-            before_val = format!("{before}");
-            xml_event = xml_event.attr("w:before", &before_val)
+            xml_event = xml_event.attr_display("w:before", before)
         }
         if let Some(after) = after {
-            after_val = format!("{after}");
-            xml_event = xml_event.attr("w:after", &after_val)
+            xml_event = xml_event.attr_display("w:after", after)
         }
         if let Some(before_lines) = before_lines {
-            before_lines_val = format!("{before_lines}");
-            xml_event = xml_event.attr("w:beforeLines", &before_lines_val)
+            xml_event = xml_event.attr_display("w:beforeLines", before_lines)
         }
         if let Some(after_lines) = after_lines {
-            after_lines_val = format!("{after_lines}");
-            xml_event = xml_event.attr("w:afterLines", &after_lines_val)
+            xml_event = xml_event.attr_display("w:afterLines", after_lines)
         }
         if let Some(line) = line {
-            line_val = format!("{line}");
-            xml_event = xml_event.attr("w:line", &line_val)
+            xml_event = xml_event.attr_display("w:line", line)
         }
         if let Some(spacing_type) = spacing {
             match spacing_type {
@@ -609,15 +591,14 @@ impl<W: Write> XMLBuilder<W> {
         done: bool,
         parent_paragraph_id: &Option<String>,
     ) -> Result<Self> {
-        let done = format!("{}", done as usize);
         let el = match parent_paragraph_id {
             Some(parent_paragraph_id) => XmlEvent::start_element("w15:commentEx")
                 .attr("w15:paraId", paragraph_id)
                 .attr("w15:paraIdParent", parent_paragraph_id)
-                .attr("w15:done", &done),
+                .attr_display("w15:done", done as usize),
             None => XmlEvent::start_element("w15:commentEx")
                 .attr("w15:paraId", paragraph_id)
-                .attr("w15:done", &done),
+                .attr_display("w15:done", done as usize),
         };
         self.write(el)?.close()
     }
@@ -629,15 +610,12 @@ impl<W: Write> XMLBuilder<W> {
         line_pitch: Option<usize>,
         char_space: Option<isize>,
     ) -> Result<Self> {
-        let t = t.to_string();
-        let line_pitch_string = format!("{}", line_pitch.unwrap_or_default());
-        let char_space_string = format!("{}", char_space.unwrap_or_default());
-        let mut w = XmlEvent::start_element("w:docGrid").attr("w:type", &t);
-        if line_pitch.is_some() {
-            w = w.attr("w:linePitch", &line_pitch_string);
+        let mut w = XmlEvent::start_element("w:docGrid").attr_display("w:type", t);
+        if let Some(line_pitch) = line_pitch {
+            w = w.attr_display("w:linePitch", line_pitch);
         }
-        if char_space.is_some() {
-            w = w.attr("w:charSpace", &char_space_string);
+        if let Some(char_space) = char_space {
+            w = w.attr_display("w:charSpace", char_space);
         }
         self.write(w)?.close()
     }
@@ -668,29 +646,23 @@ impl<W: Write> XMLBuilder<W> {
         if prop.y_align.is_some() {
             w = w.attr("w:yAlign", &y_align);
         }
-        let x: String = format!("{}", prop.x.unwrap_or_default());
-        if prop.x.is_some() {
-            w = w.attr("w:x", &x);
+        if let Some(x) = prop.x {
+            w = w.attr_display("w:x", x);
         }
-        let y: String = format!("{}", prop.y.unwrap_or_default());
-        if prop.y.is_some() {
-            w = w.attr("w:y", &y);
+        if let Some(y) = prop.y {
+            w = w.attr_display("w:y", y);
         }
-        let h_space: String = format!("{}", prop.h_space.unwrap_or_default());
-        if prop.h_space.is_some() {
-            w = w.attr("w:h_space", &h_space);
+        if let Some(h_space) = prop.h_space {
+            w = w.attr_display("w:h_space", h_space);
         }
-        let v_space: String = format!("{}", prop.v_space.unwrap_or_default());
-        if prop.v_space.is_some() {
-            w = w.attr("w:v_space", &v_space);
+        if let Some(v_space) = prop.v_space {
+            w = w.attr_display("w:v_space", v_space);
         }
-        let width: String = format!("{}", prop.w.unwrap_or_default());
-        if prop.w.is_some() {
-            w = w.attr("w:w", &width);
+        if let Some(width) = prop.w {
+            w = w.attr_display("w:w", width);
         }
-        let h: String = format!("{}", prop.h.unwrap_or_default());
-        if prop.h.is_some() {
-            w = w.attr("w:h", &h);
+        if let Some(height) = prop.h {
+            w = w.attr_display("w:h", height);
         }
         self.write(w)?.close()
     }
@@ -698,14 +670,12 @@ impl<W: Write> XMLBuilder<W> {
     pub(crate) fn table_position_property(self, prop: &TablePositionProperty) -> Result<Self> {
         let mut w = XmlEvent::start_element("w:tblpPr");
 
-        let v: String = format!("{}", prop.left_from_text.unwrap_or_default());
-        if prop.left_from_text.is_some() {
-            w = w.attr("w:leftFromText", &v);
+        if let Some(left_from_text) = prop.left_from_text {
+            w = w.attr_display("w:leftFromText", left_from_text);
         }
 
-        let v: String = format!("{}", prop.right_from_text.unwrap_or_default());
-        if prop.right_from_text.is_some() {
-            w = w.attr("w:rightFromText", &v);
+        if let Some(right_from_text) = prop.right_from_text {
+            w = w.attr_display("w:rightFromText", right_from_text);
         }
 
         let v: String = prop.vertical_anchor.iter().cloned().collect();
@@ -728,14 +698,12 @@ impl<W: Write> XMLBuilder<W> {
             w = w.attr("w:tblpYSpec", &v);
         }
 
-        let v: String = format!("{}", prop.position_x.unwrap_or_default());
-        if prop.position_x.is_some() {
-            w = w.attr("w:tblpX", &v);
+        if let Some(position_x) = prop.position_x {
+            w = w.attr_display("w:tblpX", position_x);
         }
 
-        let v: String = format!("{}", prop.position_y.unwrap_or_default());
-        if prop.position_y.is_some() {
-            w = w.attr("w:tblpY", &v);
+        if let Some(position_y) = prop.position_y {
+            w = w.attr_display("w:tblpY", position_y);
         }
 
         self.write(w)?.close()
@@ -747,13 +715,11 @@ impl<W: Write> XMLBuilder<W> {
         chap_style: Option<String>,
     ) -> Result<Self> {
         let mut w = XmlEvent::start_element("w:pgNumType");
-        let start_string = format!("{}", start.unwrap_or_default());
-        let chap_style_string = chap_style.clone().unwrap_or_default();
-        if start.is_some() {
-            w = w.attr("w:start", &start_string);
+        if let Some(start) = start {
+            w = w.attr_display("w:start", start);
         }
-        if chap_style.is_some() {
-            w = w.attr("w:chapStyle", &chap_style_string);
+        if let Some(chap_style) = chap_style.as_deref() {
+            w = w.attr("w:chapStyle", chap_style);
         }
         self.write(w)?.close()
     }
@@ -764,31 +730,17 @@ impl<W: Write> XMLBuilder<W> {
         leader: Option<TabLeaderType>,
         pos: Option<usize>,
     ) -> Result<Self> {
-        let v_string = if let Some(v) = v {
-            v.to_string()
-        } else {
-            "".to_string()
-        };
-
-        let leader_string = if let Some(leader) = leader {
-            leader.to_string()
-        } else {
-            "".to_string()
-        };
-
-        let pos_string = format!("{}", pos.unwrap_or_default());
-
         let mut t = XmlEvent::start_element("w:tab");
-        if v.is_some() {
-            t = t.attr("w:val", &v_string);
+        if let Some(v) = v {
+            t = t.attr_display("w:val", v);
         }
 
-        if leader.is_some() {
-            t = t.attr("w:leader", &leader_string);
+        if let Some(leader) = leader {
+            t = t.attr_display("w:leader", leader);
         }
 
-        if pos.is_some() {
-            t = t.attr("w:pos", &pos_string);
+        if let Some(pos) = pos {
+            t = t.attr_display("w:pos", pos);
         }
         self.write(t)?.close()
     }
@@ -799,15 +751,10 @@ impl<W: Write> XMLBuilder<W> {
         relative_to: PositionalTabRelativeTo,
         leader: TabLeaderType,
     ) -> Result<Self> {
-        let alignment_string = alignment.to_string();
-        let relative_to_string = relative_to.to_string();
-        let leader_string = leader.to_string();
-
-        let mut t = XmlEvent::start_element("w:ptab");
-
-        t = t.attr("w:alignment", &alignment_string);
-        t = t.attr("w:relativeTo", &relative_to_string);
-        t = t.attr("w:leader", &leader_string);
+        let t = XmlEvent::start_element("w:ptab")
+            .attr_display("w:alignment", alignment)
+            .attr_display("w:relativeTo", relative_to)
+            .attr_display("w:leader", leader);
 
         self.write(t)?.close()
     }
@@ -815,7 +762,7 @@ impl<W: Write> XMLBuilder<W> {
     // FootnoteReference
     // w:footnoteReference w:id="1"
     pub(crate) fn footnote_reference(self, id: usize) -> Result<Self> {
-        self.write(XmlEvent::start_element("w:footnoteReference").attr("w:id", &id.to_string()))?
+        self.write(XmlEvent::start_element("w:footnoteReference").attr_display("w:id", id))?
             .close()
     }
 

--- a/docx-core/src/xml_builder/macros.rs
+++ b/docx-core/src/xml_builder/macros.rs
@@ -480,7 +480,7 @@ macro_rules! closed_with_str {
 macro_rules! closed_with_usize {
     ($name: ident, $el_name: expr) => {
         pub(crate) fn $name(self, val: usize) -> crate::xml::writer::Result<Self> {
-            self.write(XmlEvent::start_element($el_name).attr("w:val", &format!("{}", val)))?
+            self.write(XmlEvent::start_element($el_name).attr_display("w:val", val))?
                 .close()
         }
     };
@@ -489,7 +489,7 @@ macro_rules! closed_with_usize {
 macro_rules! closed_with_isize {
     ($name: ident, $el_name: expr) => {
         pub(crate) fn $name(self, val: isize) -> crate::xml::writer::Result<Self> {
-            self.write(XmlEvent::start_element($el_name).attr("w:val", &format!("{}", val)))?
+            self.write(XmlEvent::start_element($el_name).attr_display("w:val", val))?
                 .close()
         }
     };
@@ -500,8 +500,8 @@ macro_rules! closed_w_with_type_el {
         pub(crate) fn $name(self, w: i32, t: WidthType) -> crate::xml::writer::Result<Self> {
             self.write(
                 XmlEvent::start_element($el_name)
-                    .attr("w:w", &format!("{}", w))
-                    .attr("w:type", &t.to_string()),
+                    .attr_display("w:w", w)
+                    .attr_display("w:type", t),
             )?
             .close()
         }
@@ -519,9 +519,9 @@ macro_rules! closed_border_el {
         ) -> crate::xml::writer::Result<Self> {
             self.write(
                 XmlEvent::start_element($el_name)
-                    .attr("w:val", &val.to_string())
-                    .attr("w:sz", &format!("{}", size))
-                    .attr("w:space", &format!("{}", space))
+                    .attr_display("w:val", val)
+                    .attr_display("w:sz", size)
+                    .attr_display("w:space", space)
                     .attr("w:color", color),
             )?
             .close()


### PR DESCRIPTION
## Summary

- reduce XML writer allocations by encoding start tags into reusable byte buffers and writing numeric attribute values directly
- make XML escaping, entity decoding, QName parsing, ZIP reads, and relationship lookups single-pass or borrowed where possible
- skip redundant paragraph-ID and dependency traversals when no repair or comment processing is required
- preserve PNG bytes, index image deduplication by ID/fingerprint, and reuse the index across document/header/footer traversal
- use a fast length/CRC fingerprint with byte comparison on collisions for image deduplication
- add `ReadDocxOptions` so callers that do not need PNG previews can skip expensive non-PNG decoding/re-encoding
- expand Criterion coverage for build vs. pack, large documents, repeated images, PNG/JPEG reads, and preview-free reads

## Benchmarks

Quick Criterion runs on this branch:

- `write_docx_build_pack`: ~1.63 ms → ~0.88 ms (about 46% faster)
- `write_docx_repeated_images`: ~1.89 ms → ~1.24 ms after the fingerprint follow-up (about 34% faster)
- `read_docx_hello`: ~326 µs → ~142 µs (about 56% faster)
- JPEG read with previews disabled: ~36.8 ms → ~122 µs for the same fixture (about 300x faster); original image bytes remain available

The default `read_docx` behavior is unchanged. Preview generation is disabled explicitly with:

```rust
read_docx_with_options(
    bytes,
    ReadDocxOptions::default().with_image_previews(false),
)
```

## Validation

- `cargo fmt --all -- --check`
- `CARGO_INCREMENTAL=0 cargo test --workspace -- --test-threads=1`
- `CARGO_INCREMENTAL=0 cargo test -p docx-rs --lib --no-default-features`
- `CARGO_INCREMENTAL=0 cargo clippy --workspace --all-targets -- -D warnings`
- `CARGO_INCREMENTAL=0 cargo bench --workspace --no-run`
- `cargo doc --workspace --no-deps`

Integration snapshots are run single-threaded because the existing global paragraph ID generator can race between parallel snapshot tests.
