### PR TITLE
Improve DOCX construction and build preparation

### DIFF
--- a/docx-core/benches/write_docx.rs
+++ b/docx-core/benches/write_docx.rs
@@ -18,6 +18,10 @@ fn create_template(paragraph_count: usize, runs_per_paragraph: usize) -> Docx {
 }
 
 fn bench_write_docx(c: &mut Criterion) {
+    c.bench_function("write_docx_construct", |b| {
+        b.iter(|| black_box(create_template(200, 5)));
+    });
+
     let template = create_template(200, 5);
     c.bench_function("write_docx_build", |b| {
         b.iter_batched(

--- a/docx-core/benches/write_docx.rs
+++ b/docx-core/benches/write_docx.rs
@@ -57,6 +57,18 @@ fn bench_write_docx(c: &mut Criterion) {
         );
     });
 
+    c.bench_function("write_docx_direct_pack", |b| {
+        b.iter_batched(
+            || template.clone(),
+            |docx| {
+                let mut cursor = Cursor::new(Vec::with_capacity(64 * 1024));
+                docx.pack(&mut cursor).expect("failed to write docx");
+                black_box(cursor.into_inner());
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
     let large_template = create_template(2_000, 5);
     c.bench_function("write_docx_large_build_pack", |b| {
         b.iter_batched(

--- a/docx-core/src/documents/build_xml.rs
+++ b/docx-core/src/documents/build_xml.rs
@@ -1,6 +1,7 @@
 use crate::xml_builder::XMLBuilder;
 use std::io::Write;
 
+/// Renders an OOXML package part to an XML byte stream.
 pub trait BuildXML {
     /// Write XML to the output stream.
     #[doc(hidden)]

--- a/docx-core/src/documents/document_rels.rs
+++ b/docx-core/src/documents/document_rels.rs
@@ -40,7 +40,7 @@ impl DocumentRels {
         r#type: impl Into<String>,
     ) -> Self {
         self.hyperlinks
-            .push((id.into(), escape(&path.into()), r#type.into()));
+            .push((id.into(), escape_owned(path.into()), r#type.into()));
         self
     }
 }

--- a/docx-core/src/documents/elements/based_on.rs
+++ b/docx-core/src/documents/elements/based_on.rs
@@ -2,7 +2,7 @@ use serde::{Serialize, Serializer};
 use std::io::Write;
 
 use crate::documents::BuildXML;
-use crate::escape::escape;
+use crate::escape::escape_owned;
 use crate::xml_builder::*;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -13,7 +13,7 @@ pub struct BasedOn {
 impl BasedOn {
     pub fn new(val: impl Into<String>) -> BasedOn {
         BasedOn {
-            val: escape(&val.into()),
+            val: escape_owned(val.into()),
         }
     }
 }

--- a/docx-core/src/documents/elements/delete.rs
+++ b/docx-core/src/documents/elements/delete.rs
@@ -85,7 +85,7 @@ impl Delete {
     }
 
     pub fn author(mut self, author: impl Into<String>) -> Delete {
-        self.author = escape::escape(&author.into());
+        self.author = escape::escape_owned(author.into());
         self
     }
 

--- a/docx-core/src/documents/elements/delete_text.rs
+++ b/docx-core/src/documents/elements/delete_text.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use std::io::Write;
 
 use crate::documents::BuildXML;
-use crate::escape::escape;
+use crate::escape::escape_owned;
 use crate::xml_builder::*;
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
@@ -15,7 +15,7 @@ pub struct DeleteText {
 impl DeleteText {
     pub fn new(text: impl Into<String>) -> DeleteText {
         DeleteText {
-            text: escape(&text.into()),
+            text: escape_owned(text.into()),
             preserve_space: true,
         }
     }

--- a/docx-core/src/documents/elements/hyperlink.rs
+++ b/docx-core/src/documents/elements/hyperlink.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 
 use super::*;
 use crate::documents::BuildXML;
-use crate::escape::escape;
+use crate::escape::escape_owned;
 use crate::types::*;
 use crate::{create_hyperlink_rid, generate_hyperlink_id, xml_builder::*};
 
@@ -37,7 +37,7 @@ impl Hyperlink {
             match t {
                 HyperlinkType::External => HyperlinkData::External {
                     rid: create_hyperlink_rid(generate_hyperlink_id()),
-                    path: escape(&value.into()),
+                    path: escape_owned(value.into()),
                 },
                 HyperlinkType::Anchor => HyperlinkData::Anchor {
                     anchor: value.into(),

--- a/docx-core/src/documents/elements/insert.rs
+++ b/docx-core/src/documents/elements/insert.rs
@@ -131,7 +131,7 @@ impl Insert {
     }
 
     pub fn author(mut self, author: impl Into<String>) -> Insert {
-        self.author = escape::escape(&author.into());
+        self.author = escape::escape_owned(author.into());
         self
     }
 

--- a/docx-core/src/documents/elements/instr_tc.rs
+++ b/docx-core/src/documents/elements/instr_tc.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 use std::io::Write;
 
 use crate::documents::*;
-use crate::escape::escape;
+use crate::escape::escape_owned;
 use crate::xml_builder::XMLBuilder;
 
 // https://c-rex.net/projects/samples/ooxml/e1/Part4/OOXML_P4_DOCX_TCTC_topic_ID0EU2N1.html
@@ -20,7 +20,7 @@ pub struct InstrTC {
 impl InstrTC {
     pub fn new(text: impl Into<String>) -> Self {
         Self {
-            text: escape(&text.into()),
+            text: escape_owned(text.into()),
             ..Default::default()
         }
     }

--- a/docx-core/src/documents/elements/link.rs
+++ b/docx-core/src/documents/elements/link.rs
@@ -2,7 +2,7 @@ use serde::{Serialize, Serializer};
 use std::io::Write;
 
 use crate::documents::BuildXML;
-use crate::escape::escape;
+use crate::escape::escape_owned;
 use crate::xml_builder::*;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -13,7 +13,7 @@ pub struct Link {
 impl Link {
     pub fn new(val: impl Into<String>) -> Link {
         Link {
-            val: escape(&val.into()),
+            val: escape_owned(val.into()),
         }
     }
 }

--- a/docx-core/src/documents/elements/move_from.rs
+++ b/docx-core/src/documents/elements/move_from.rs
@@ -84,7 +84,7 @@ impl MoveFrom {
     }
 
     pub fn author(mut self, author: impl Into<String>) -> MoveFrom {
-        self.author = escape::escape(&author.into());
+        self.author = escape::escape_owned(author.into());
         self
     }
 

--- a/docx-core/src/documents/elements/move_to.rs
+++ b/docx-core/src/documents/elements/move_to.rs
@@ -124,7 +124,7 @@ impl MoveTo {
     }
 
     pub fn author(mut self, author: impl Into<String>) -> MoveTo {
-        self.author = escape::escape(&author.into());
+        self.author = escape::escape_owned(author.into());
         self
     }
 

--- a/docx-core/src/documents/elements/name.rs
+++ b/docx-core/src/documents/elements/name.rs
@@ -14,7 +14,7 @@ pub struct Name {
 impl Name {
     pub fn new(name: impl Into<String>) -> Name {
         Name {
-            name: escape::escape(&name.into()),
+            name: escape::escape_owned(name.into()),
         }
     }
 

--- a/docx-core/src/documents/elements/paragraph_property_change.rs
+++ b/docx-core/src/documents/elements/paragraph_property_change.rs
@@ -36,7 +36,7 @@ impl ParagraphPropertyChange {
     }
 
     pub fn author(mut self, author: impl Into<String>) -> ParagraphPropertyChange {
-        self.author = escape::escape(&author.into());
+        self.author = escape::escape_owned(author.into());
         self
     }
 

--- a/docx-core/src/documents/elements/paragraph_style.rs
+++ b/docx-core/src/documents/elements/paragraph_style.rs
@@ -2,7 +2,7 @@ use serde::{Serialize, Serializer};
 use std::io::Write;
 
 use crate::documents::BuildXML;
-use crate::escape::escape;
+use crate::escape::escape_owned;
 use crate::xml_builder::*;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -28,7 +28,7 @@ impl ParagraphStyle {
     pub fn new(val: Option<impl Into<String>>) -> ParagraphStyle {
         if let Some(v) = val {
             ParagraphStyle {
-                val: escape(&v.into()),
+                val: escape_owned(v.into()),
             }
         } else {
             Default::default()

--- a/docx-core/src/documents/elements/run_fonts.rs
+++ b/docx-core/src/documents/elements/run_fonts.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use std::io::Write;
 
 use crate::documents::BuildXML;
-use crate::escape::escape;
+use crate::escape::escape_owned;
 use crate::xml_builder::*;
 
 /*
@@ -42,56 +42,47 @@ impl RunFonts {
     }
 
     pub fn ascii(mut self, f: impl Into<String>) -> Self {
-        let s = f.into();
-        self.ascii = Some(escape(&s));
+        self.ascii = Some(escape_owned(f.into()));
         self
     }
 
     pub fn hi_ansi(mut self, f: impl Into<String>) -> Self {
-        let s = f.into();
-        self.hi_ansi = Some(escape(&s));
+        self.hi_ansi = Some(escape_owned(f.into()));
         self
     }
 
     pub fn east_asia(mut self, f: impl Into<String>) -> Self {
-        let s = f.into();
-        self.east_asia = Some(escape(&s));
+        self.east_asia = Some(escape_owned(f.into()));
         self
     }
 
     pub fn cs(mut self, f: impl Into<String>) -> Self {
-        let s = f.into();
-        self.cs = Some(escape(&s));
+        self.cs = Some(escape_owned(f.into()));
         self
     }
 
     pub fn ascii_theme(mut self, f: impl Into<String>) -> Self {
-        let s = f.into();
-        self.ascii_theme = Some(escape(&s));
+        self.ascii_theme = Some(escape_owned(f.into()));
         self
     }
 
     pub fn hi_ansi_theme(mut self, f: impl Into<String>) -> Self {
-        let s = f.into();
-        self.hi_ansi_theme = Some(escape(&s));
+        self.hi_ansi_theme = Some(escape_owned(f.into()));
         self
     }
 
     pub fn east_asia_theme(mut self, f: impl Into<String>) -> Self {
-        let s = f.into();
-        self.east_asia_theme = Some(escape(&s));
+        self.east_asia_theme = Some(escape_owned(f.into()));
         self
     }
 
     pub fn cs_theme(mut self, f: impl Into<String>) -> Self {
-        let s = f.into();
-        self.cs_theme = Some(escape(&s));
+        self.cs_theme = Some(escape_owned(f.into()));
         self
     }
 
     pub fn hint(mut self, f: impl Into<String>) -> Self {
-        let s = f.into();
-        self.hint = Some(escape(&s));
+        self.hint = Some(escape_owned(f.into()));
         self
     }
 }

--- a/docx-core/src/documents/elements/run_style.rs
+++ b/docx-core/src/documents/elements/run_style.rs
@@ -2,7 +2,7 @@ use serde::{Serialize, Serializer};
 use std::io::Write;
 
 use crate::documents::BuildXML;
-use crate::escape::escape;
+use crate::escape::escape_owned;
 use crate::xml_builder::*;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -21,7 +21,7 @@ impl Default for RunStyle {
 impl RunStyle {
     pub fn new(val: impl Into<String>) -> RunStyle {
         RunStyle {
-            val: escape(&val.into()),
+            val: escape_owned(val.into()),
         }
     }
 }

--- a/docx-core/src/documents/elements/style.rs
+++ b/docx-core/src/documents/elements/style.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 use std::io::Write;
 
 use crate::documents::BuildXML;
-use crate::escape::escape;
+use crate::escape::escape_owned;
 use crate::types::*;
 use crate::xml_builder::*;
 use crate::StyleType;
@@ -69,7 +69,7 @@ impl Style {
     pub fn new(style_id: impl Into<String>, style_type: StyleType) -> Self {
         let default = Default::default();
         Style {
-            style_id: escape(&style_id.into()),
+            style_id: escape_owned(style_id.into()),
             style_type,
             ..default
         }

--- a/docx-core/src/documents/elements/table_of_contents.rs
+++ b/docx-core/src/documents/elements/table_of_contents.rs
@@ -40,7 +40,7 @@ pub struct TableOfContentsReviewData {
     pub date: String,
 }
 
-/// https://c-rex.net/projects/samples/ooxml/e1/Part4/OOXML_P4_DOCX_TOCTOC_topic_ID0ELZO1.html
+/// <https://c-rex.net/projects/samples/ooxml/e1/Part4/OOXML_P4_DOCX_TOCTOC_topic_ID0ELZO1.html>
 /// This struct is only used by writers
 #[derive(Serialize, Debug, Clone, PartialEq, Default)]
 pub struct TableOfContents {
@@ -105,7 +105,7 @@ impl TableOfContents {
 
     pub fn delete(mut self, author: impl Into<String>, date: impl Into<String>) -> Self {
         self.delete = Some(TableOfContentsReviewData {
-            author: escape::escape(&author.into()),
+            author: escape::escape_owned(author.into()),
             date: date.into(),
         });
         self

--- a/docx-core/src/documents/elements/table_position_property.rs
+++ b/docx-core/src/documents/elements/table_position_property.rs
@@ -4,7 +4,7 @@ use std::io::Write;
 use crate::documents::BuildXML;
 use crate::xml_builder::*;
 
-/// https://learn.microsoft.com/en-us/dotnet/api/documentformat.openxml.wordprocessing.tablepositionproperties?view=openxml-3.0.1
+/// <https://learn.microsoft.com/en-us/dotnet/api/documentformat.openxml.wordprocessing.tablepositionproperties?view=openxml-3.0.1>
 #[derive(Debug, Clone, PartialEq, Serialize, Default)]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "wasm", derive(ts_rs::TS), ts(export))]

--- a/docx-core/src/documents/elements/text.rs
+++ b/docx-core/src/documents/elements/text.rs
@@ -3,7 +3,7 @@ use serde::Deserialize;
 use std::io::Write;
 
 use crate::documents::BuildXML;
-use crate::escape::escape;
+use crate::escape::escape_owned;
 use crate::xml_builder::*;
 
 #[derive(Debug, Clone, Deserialize, PartialEq)]
@@ -16,7 +16,7 @@ pub struct Text {
 impl Text {
     pub fn new(text: impl Into<String>) -> Text {
         Text {
-            text: escape(&text.into()),
+            text: escape_owned(text.into()),
             preserve_space: true,
         }
     }

--- a/docx-core/src/documents/mod.rs
+++ b/docx-core/src/documents/mod.rs
@@ -174,6 +174,13 @@ pub struct Docx {
     pub footnotes: Footnotes,
 }
 
+/// Package metadata derived while normalizing a document for output.
+pub(crate) struct PackageMetadata {
+    pub(crate) media: Vec<ImageIdAndBuf>,
+    pub(crate) header_rels: Vec<HeaderRels>,
+    pub(crate) footer_rels: Vec<FooterRels>,
+}
+
 impl Default for Docx {
     fn default() -> Self {
         let content_type = ContentTypes::new().set_default();
@@ -766,27 +773,7 @@ impl Docx {
     /// This consumes the document. Call [`XMLDocx::pack`] to write a DOCX
     /// archive.
     pub fn build(mut self) -> XMLDocx {
-        let has_toc = self.prepare_for_build();
-
-        let (images, mut images_bufs) = self.images_in_doc();
-        let (header_images, header_images_bufs) = self.images_in_header();
-        let (footer_images, footer_images_bufs) = self.images_in_footer();
-
-        images_bufs.extend(header_images_bufs);
-        images_bufs.extend(footer_images_bufs);
-
-        let mut header_rels = vec![HeaderRels::new(); 3];
-        for (i, images) in header_images.iter().enumerate() {
-            if let Some(h) = header_rels.get_mut(i) {
-                h.set_images(images.to_owned());
-            }
-        }
-        let mut footer_rels = vec![FooterRels::new(); 3];
-        for (i, images) in footer_images.iter().enumerate() {
-            if let Some(f) = footer_rels.get_mut(i) {
-                f.set_images(images.to_owned());
-            }
-        }
+        let package = self.prepare_package();
 
         let web_extensions = self.web_extensions.iter().map(|ext| ext.build()).collect();
         let custom_items = self.custom_items.iter().map(|xml| xml.build()).collect();
@@ -796,8 +783,6 @@ impl Docx {
             .iter()
             .map(|rel| rel.build())
             .collect();
-
-        self.document_rels.images = images;
 
         let mut headers: Vec<&(String, Header)> = self.document.section_property.get_headers();
 
@@ -825,28 +810,6 @@ impl Docx {
         footers.sort_by(|a, b| a.0.cmp(&b.0));
         let footers = footers.iter().map(|h| h.1.build()).collect();
 
-        // Collect footnotes
-        if self.collect_footnotes() {
-            // Relationship entry for footnotes
-            self.content_type = self.content_type.add_footnotes();
-            self.document_rels.has_footnotes = true;
-        }
-
-        if has_toc {
-            for i in 1..=9 {
-                if !self
-                    .styles
-                    .styles
-                    .iter()
-                    .any(|s| s.name == Name::new(format!("toc {i}")))
-                {
-                    self.styles = self
-                        .styles
-                        .add_style(crate::documents::preset_styles::toc(i));
-                }
-            }
-        }
-
         XMLDocx {
             content_type: self.content_type.build(),
             rels: self.rels.build(),
@@ -855,12 +818,12 @@ impl Docx {
             document: self.document.build(),
             comments: self.comments.build(),
             document_rels: self.document_rels.build(),
-            header_rels: header_rels.into_iter().map(|r| r.build()).collect(),
-            footer_rels: footer_rels.into_iter().map(|r| r.build()).collect(),
+            header_rels: package.header_rels.into_iter().map(|r| r.build()).collect(),
+            footer_rels: package.footer_rels.into_iter().map(|r| r.build()).collect(),
             settings: self.settings.build(),
             font_table: self.font_table.build(),
             numberings: self.numberings.build(),
-            media: images_bufs,
+            media: package.media,
             headers,
             footers,
             comments_extended: self.comments_extended.build(),
@@ -872,6 +835,19 @@ impl Docx {
             custom_item_props,
             footnotes: self.footnotes.build(),
         }
+    }
+
+    /// Writes this document directly as a DOCX ZIP archive.
+    ///
+    /// Unlike [`Docx::build`] followed by [`XMLDocx::pack`], this method
+    /// streams XML package parts into the archive instead of retaining every
+    /// rendered part in a separate `Vec<u8>`.
+    pub fn pack<W>(mut self, writer: W) -> zip::result::ZipResult<()>
+    where
+        W: std::io::Write + std::io::Seek,
+    {
+        let package = self.prepare_package();
+        crate::zipper::zip_docx(writer, self, package)
     }
 
     pub fn json(&self) -> String {
@@ -931,6 +907,54 @@ impl Docx {
         self.refresh_duplicate_para_ids();
         self.update_dependencies();
         has_toc
+    }
+
+    /// Normalizes the document and collects metadata shared by buffered and
+    /// streaming package output.
+    fn prepare_package(&mut self) -> PackageMetadata {
+        let has_toc = self.prepare_for_build();
+
+        let (images, mut media) = self.images_in_doc();
+        let (header_images, header_media) = self.images_in_header();
+        let (footer_images, footer_media) = self.images_in_footer();
+        media.extend(header_media);
+        media.extend(footer_media);
+        self.document_rels.images = images;
+
+        let mut header_rels = vec![HeaderRels::new(); 3];
+        for (rels, images) in header_rels.iter_mut().zip(header_images) {
+            rels.set_images(images);
+        }
+
+        let mut footer_rels = vec![FooterRels::new(); 3];
+        for (rels, images) in footer_rels.iter_mut().zip(footer_images) {
+            rels.set_images(images);
+        }
+
+        if self.collect_footnotes() {
+            self.content_type = std::mem::take(&mut self.content_type).add_footnotes();
+            self.document_rels.has_footnotes = true;
+        }
+
+        if has_toc {
+            for level in 1..=9 {
+                if !self
+                    .styles
+                    .styles
+                    .iter()
+                    .any(|style| style.name == Name::new(format!("toc {level}")))
+                {
+                    self.styles = std::mem::take(&mut self.styles)
+                        .add_style(crate::documents::preset_styles::toc(level));
+                }
+            }
+        }
+
+        PackageMetadata {
+            media,
+            header_rels,
+            footer_rels,
+        }
     }
 
     /// Replaces empty and duplicate paragraph IDs with unique values.
@@ -2467,12 +2491,23 @@ fn ensure_unique_paragraph_id(
         return;
     }
 
-    let mut new_id = crate::generate_para_id();
-    while used.contains(&new_id) {
-        new_id = crate::generate_para_id();
-    }
+    let new_id = next_unique_paragraph_id(used);
     paragraph.id = new_id.clone();
     used.insert(new_id);
+}
+
+/// Returns a generated paragraph ID, falling back to a deterministic scan if
+/// the generator collides with an existing value.
+fn next_unique_paragraph_id(used: &HashSet<String>) -> String {
+    let generated = crate::generate_para_id();
+    if !used.contains(&generated) {
+        return generated;
+    }
+
+    (1usize..)
+        .map(|value| format!("{value:08x}"))
+        .find(|candidate| !used.contains(candidate))
+        .expect("the paragraph ID space should not be exhausted")
 }
 
 fn push_comment_and_comment_extended(
@@ -2620,6 +2655,40 @@ mod image_collection_tests {
 
         assert!(relationships[0][0].0.starts_with("footer"));
         assert!(media[0].0.starts_with("footer"));
+    }
+}
+
+#[cfg(test)]
+mod pack_tests {
+    use super::*;
+    use std::io::Cursor;
+
+    #[test]
+    fn direct_pack_matches_buffered_package_output() {
+        let image = vec![1, 2, 3, 4];
+        let header = Header::new().add_paragraph(
+            Paragraph::new().add_run(Run::new().add_image(Pic::new_with_dimensions(
+                image.clone(),
+                1,
+                1,
+            ))),
+        );
+        let footer = Footer::new().add_paragraph(
+            Paragraph::new().add_run(Run::new().add_image(Pic::new_with_dimensions(image, 1, 1))),
+        );
+        let docx = Docx::new()
+            .header(header)
+            .footer(footer)
+            .add_paragraph(Paragraph::new().add_run(Run::new().add_text("streamed package")));
+
+        let mut buffered = Cursor::new(Vec::new());
+        let xml = docx.clone().build();
+        xml.pack(&mut buffered).unwrap();
+
+        let mut streamed = Cursor::new(Vec::new());
+        docx.pack(&mut streamed).unwrap();
+
+        assert_eq!(streamed.into_inner(), buffered.into_inner());
     }
 }
 

--- a/docx-core/src/documents/mod.rs
+++ b/docx-core/src/documents/mod.rs
@@ -760,35 +760,13 @@ impl Docx {
         self
     }
 
+    /// Finalizes document-wide identifiers and relationships and renders the
+    /// uncompressed OPC package parts.
+    ///
+    /// This consumes the document. Call [`XMLDocx::pack`] to write a DOCX
+    /// archive.
     pub fn build(mut self) -> XMLDocx {
-        self.reset();
-        self.refresh_duplicate_para_ids();
-
-        self.update_dependencies();
-
-        let tocs: Vec<(usize, Box<TableOfContents>)> = self
-            .document
-            .children
-            .iter()
-            .enumerate()
-            .filter_map(|(i, child)| {
-                if let DocumentChild::TableOfContents(toc) = child {
-                    Some((i, toc.clone()))
-                } else {
-                    None
-                }
-            })
-            .collect();
-
-        let has_toc = !tocs.is_empty();
-
-        for (i, toc) in tocs {
-            if toc.items.is_empty() && toc.auto {
-                let children =
-                    update_document_by_toc(self.document.children, &self.styles, *toc, i);
-                self.document.children = children;
-            }
-        }
+        let has_toc = self.prepare_for_build();
 
         let (images, mut images_bufs) = self.images_in_doc();
         let (header_images, header_images_bufs) = self.images_in_header();
@@ -921,6 +899,41 @@ impl Docx {
         crate::reset_para_id();
     }
 
+    /// Expands automatically generated tables of contents before the document
+    /// tree is normalized and inspected for dependencies.
+    fn expand_auto_tocs(&mut self) -> bool {
+        let tocs: Vec<(usize, Box<TableOfContents>)> = self
+            .document
+            .children
+            .iter()
+            .enumerate()
+            .filter_map(|(index, child)| match child {
+                DocumentChild::TableOfContents(toc) => Some((index, toc.clone())),
+                _ => None,
+            })
+            .collect();
+
+        for (index, toc) in &tocs {
+            if toc.items.is_empty() && toc.auto {
+                let children = std::mem::take(&mut self.document.children);
+                self.document.children =
+                    update_document_by_toc(children, &self.styles, *toc.clone(), *index);
+            }
+        }
+
+        !tocs.is_empty()
+    }
+
+    /// Prepares the complete document tree for package-part rendering.
+    fn prepare_for_build(&mut self) -> bool {
+        self.reset();
+        let has_toc = self.expand_auto_tocs();
+        self.refresh_duplicate_para_ids();
+        self.update_dependencies();
+        has_toc
+    }
+
+    /// Replaces empty and duplicate paragraph IDs with unique values.
     fn refresh_duplicate_para_ids(&mut self) {
         let mut counts: HashMap<&str, usize> = HashMap::new();
         collect_para_ids_in_docx(self, &mut counts);
@@ -1459,7 +1472,7 @@ impl Docx {
                                     paragraph,
                                     &mut images,
                                     &mut image_bufs,
-                                    Some("header"),
+                                    Some("footer"),
                                     &mut deduplicator,
                                 );
                             }
@@ -1468,7 +1481,7 @@ impl Docx {
                                     table,
                                     &mut images,
                                     &mut image_bufs,
-                                    Some("header"),
+                                    Some("footer"),
                                     &mut deduplicator,
                                 );
                             }
@@ -1508,7 +1521,7 @@ impl Docx {
                                     paragraph,
                                     &mut images,
                                     &mut image_bufs,
-                                    Some("header"),
+                                    Some("footer"),
                                     &mut deduplicator,
                                 );
                             }
@@ -1517,7 +1530,7 @@ impl Docx {
                                     table,
                                     &mut images,
                                     &mut image_bufs,
-                                    Some("header"),
+                                    Some("footer"),
                                     &mut deduplicator,
                                 );
                             }
@@ -1557,7 +1570,7 @@ impl Docx {
                                     paragraph,
                                     &mut images,
                                     &mut image_bufs,
-                                    Some("header"),
+                                    Some("footer"),
                                     &mut deduplicator,
                                 );
                             }
@@ -1566,7 +1579,7 @@ impl Docx {
                                     table,
                                     &mut images,
                                     &mut image_bufs,
-                                    Some("header"),
+                                    Some("footer"),
                                     &mut deduplicator,
                                 );
                             }
@@ -2588,6 +2601,29 @@ fn update_document_by_toc(
 }
 
 #[cfg(test)]
+mod image_collection_tests {
+    use super::*;
+
+    #[test]
+    fn structured_footer_images_use_footer_relationship_ids() {
+        let tag = StructuredDataTag::new().add_paragraph(
+            Paragraph::new().add_run(Run::new().add_image(Pic::new_with_dimensions(
+                vec![1, 2, 3],
+                1,
+                1,
+            ))),
+        );
+        let footer = Footer::new().add_structured_data_tag(tag);
+        let mut docx = Docx::new().footer(footer);
+
+        let (relationships, media) = docx.images_in_footer();
+
+        assert!(relationships[0][0].0.starts_with("footer"));
+        assert!(media[0].0.starts_with("footer"));
+    }
+}
+
+#[cfg(test)]
 mod paragraph_id_tests {
     use super::*;
 
@@ -2634,6 +2670,25 @@ mod paragraph_id_tests {
         docx.refresh_duplicate_para_ids();
 
         assert!(!paragraph_ids(&docx)[0].is_empty());
+    }
+
+    #[test]
+    fn auto_toc_paragraph_ids_are_normalized_after_expansion() {
+        let heading = Paragraph::new()
+            .id("00000001")
+            .style("Heading1")
+            .add_run(Run::new().add_text("Heading"));
+        let mut docx = Docx::new()
+            .add_style(Style::new("Heading1", crate::StyleType::Paragraph).name("Heading 1"))
+            .add_table_of_contents(TableOfContents::new().heading_styles_range(1, 3).auto())
+            .add_paragraph(heading);
+
+        docx.prepare_for_build();
+
+        let mut counts = HashMap::new();
+        collect_para_ids_in_docx(&docx, &mut counts);
+        assert!(!counts.contains_key(""));
+        assert!(counts.values().all(|count| *count == 1));
     }
 }
 

--- a/docx-core/src/documents/xml_docx.rs
+++ b/docx-core/src/documents/xml_docx.rs
@@ -5,6 +5,7 @@ use std::io::prelude::*;
 use std::io::Seek;
 
 #[derive(Debug)]
+/// Uncompressed OPC package parts produced by [`crate::Docx::build`].
 pub struct XMLDocx {
     pub content_type: Vec<u8>,
     pub rels: Vec<u8>,
@@ -32,6 +33,7 @@ pub struct XMLDocx {
 }
 
 impl XMLDocx {
+    /// Writes these package parts as a DOCX ZIP archive to a seekable destination.
     pub fn pack<W>(self, w: W) -> zip::result::ZipResult<()>
     where
         W: Write + Seek,

--- a/docx-core/src/escape/mod.rs
+++ b/docx-core/src/escape/mod.rs
@@ -16,6 +16,22 @@ pub(crate) fn escape(text: &str) -> String {
     escaped
 }
 
+/// Escapes an owned XML value without reallocating plain text.
+///
+/// The original `String` is returned unchanged when it contains no character
+/// that needs escaping or removal.
+pub(crate) fn escape_owned(text: String) -> String {
+    if text
+        .as_bytes()
+        .iter()
+        .any(|byte| matches!(byte, b'&' | b'<' | b'>' | b'"' | b'\'' | b'\n' | b'\r'))
+    {
+        escape(&text)
+    } else {
+        text
+    }
+}
+
 pub(crate) fn replace_escaped(text: &str) -> String {
     let mut decoded = String::with_capacity(text.len());
     let mut rest = text;
@@ -56,6 +72,24 @@ mod tests {
         assert_eq!(
             escape("<&>\"'\n\rplain"),
             "&lt;&amp;&gt;&quot;&apos;&#xA;plain"
+        );
+    }
+
+    #[test]
+    fn preserves_the_allocation_for_plain_owned_text() {
+        let text = String::from("plain text");
+        let pointer = text.as_ptr();
+        let escaped = escape_owned(text);
+
+        assert_eq!(escaped, "plain text");
+        assert_eq!(escaped.as_ptr(), pointer);
+    }
+
+    #[test]
+    fn escapes_special_characters_in_owned_text() {
+        assert_eq!(
+            escape_owned("<&>\"'\n\r".to_owned()),
+            "&lt;&amp;&gt;&quot;&apos;&#xA;"
         );
     }
 

--- a/docx-core/src/xml/writer.rs
+++ b/docx-core/src/xml/writer.rs
@@ -231,6 +231,9 @@ impl From<String> for XmlEvent<'static> {
 }
 
 impl<'a> StartElement<'a> {
+    /// Appends an attribute with an already escaped string value.
+    ///
+    /// The value is copied directly into the start tag and is not XML-escaped.
     pub fn attr(mut self, name: &str, value: &str) -> Self {
         self.encoded.push(b' ');
         self.encoded.extend_from_slice(name.as_bytes());
@@ -240,6 +243,10 @@ impl<'a> StartElement<'a> {
         self
     }
 
+    /// Appends an attribute by formatting its value directly into the start tag.
+    ///
+    /// This avoids allocating an intermediate `String`. The formatted value is
+    /// not XML-escaped.
     pub fn attr_display(mut self, name: &str, value: impl fmt::Display) -> Self {
         self.encoded.push(b' ');
         self.encoded.extend_from_slice(name.as_bytes());

--- a/docx-core/src/xml_builder/elements.rs
+++ b/docx-core/src/xml_builder/elements.rs
@@ -25,12 +25,7 @@ impl<W: Write> XMLBuilder<W> {
     }
 
     pub(crate) fn snap_to_grid(self, v: bool) -> Result<Self> {
-        let v = if v {
-            "true".to_string()
-        } else {
-            "false".to_string()
-        };
-        self.write(XmlEvent::start_element("w:snapToGrid").attr("w:val", &v))?
+        self.write(XmlEvent::start_element("w:snapToGrid").attr_display("w:val", v))?
             .close()
     }
 
@@ -123,8 +118,7 @@ impl<W: Write> XMLBuilder<W> {
         if let Some(anchor) = anchor {
             e = e.attr("w:anchor", anchor);
         }
-        let s = format!("{history}");
-        e = e.attr("w:history", s.as_str());
+        e = e.attr_display("w:history", history);
         self.write(e)
     }
 
@@ -227,7 +221,7 @@ impl<W: Write> XMLBuilder<W> {
     pub(crate) fn open_style(self, style_type: StyleType, id: &str) -> Result<Self> {
         self.write(
             XmlEvent::start_element("w:style")
-                .attr("w:type", &style_type.to_string())
+                .attr_display("w:type", style_type)
                 .attr("w:styleId", id),
         )
     }

--- a/docx-core/src/zipper/mod.rs
+++ b/docx-core/src/zipper/mod.rs
@@ -1,8 +1,34 @@
-use crate::XMLDocx;
+use crate::xml_builder::XMLBuilder;
+use crate::{BuildXML, DocumentChild, Docx, Footer, Header, PackageMetadata, XMLDocx};
 
 use std::io::prelude::*;
 use std::io::Seek;
 use zip::write::SimpleFileOptions;
+
+/// Writes one XML part directly into the current ZIP entry.
+fn write_xml<W, T>(
+    zip: &mut zip::ZipWriter<W>,
+    path: &str,
+    options: SimpleFileOptions,
+    part: &T,
+) -> zip::result::ZipResult<()>
+where
+    W: Write + Seek,
+    T: BuildXML,
+{
+    zip.start_file(path, options)?;
+    let stream = XMLBuilder::new(&mut *zip)
+        .into_inner()
+        .map_err(xml_to_zip_error)?;
+    let stream = part.build_to(stream).map_err(xml_to_zip_error)?;
+    stream.into_inner().map_err(xml_to_zip_error)?;
+    Ok(())
+}
+
+/// Converts an XML writer failure into the archive writer's error type.
+fn xml_to_zip_error(error: crate::xml::writer::Error) -> zip::result::ZipError {
+    zip::result::ZipError::Io(std::io::Error::other(error))
+}
 
 pub fn zip<W>(w: W, xml: XMLDocx) -> zip::result::ZipResult<()>
 where
@@ -110,6 +136,172 @@ where
         zip.write_all(&item)?;
         zip.start_file(format!("customXml/itemProps{n}.xml"), options)?;
         zip.write_all(&xml.custom_item_props[i])?;
+    }
+
+    zip.finish()?;
+    Ok(())
+}
+
+/// Streams a prepared document into a DOCX archive without buffering every
+/// XML package part in memory.
+pub(crate) fn zip_docx<W>(
+    writer: W,
+    docx: Docx,
+    package: PackageMetadata,
+) -> zip::result::ZipResult<()>
+where
+    W: Write + Seek,
+{
+    let mut zip = zip::ZipWriter::new(writer);
+    let directory_options = SimpleFileOptions::default();
+
+    zip.add_directory("word/", directory_options)?;
+    zip.add_directory("word/_rels", directory_options)?;
+    zip.add_directory("_rels/", directory_options)?;
+    zip.add_directory("docProps/", directory_options)?;
+
+    let options = SimpleFileOptions::default()
+        .compression_method(zip::CompressionMethod::Stored)
+        .unix_permissions(0o755);
+
+    write_xml(&mut zip, "[Content_Types].xml", options, &docx.content_type)?;
+    write_xml(&mut zip, "_rels/.rels", options, &docx.rels)?;
+    write_xml(&mut zip, "docProps/app.xml", options, &docx.doc_props.app)?;
+    write_xml(&mut zip, "docProps/core.xml", options, &docx.doc_props.core)?;
+    write_xml(
+        &mut zip,
+        "docProps/custom.xml",
+        options,
+        &docx.doc_props.custom,
+    )?;
+    write_xml(
+        &mut zip,
+        "word/_rels/document.xml.rels",
+        options,
+        &docx.document_rels,
+    )?;
+    write_xml(&mut zip, "word/document.xml", options, &docx.document)?;
+    write_xml(&mut zip, "word/styles.xml", options, &docx.styles)?;
+    write_xml(&mut zip, "word/settings.xml", options, &docx.settings)?;
+    write_xml(&mut zip, "word/fontTable.xml", options, &docx.font_table)?;
+    write_xml(&mut zip, "word/comments.xml", options, &docx.comments)?;
+    write_xml(&mut zip, "word/numbering.xml", options, &docx.numberings)?;
+    write_xml(
+        &mut zip,
+        "word/commentsExtended.xml",
+        options,
+        &docx.comments_extended,
+    )?;
+    write_xml(&mut zip, "word/footnotes.xml", options, &docx.footnotes)?;
+
+    let mut headers: Vec<&(String, Header)> = docx.document.section_property.get_headers();
+    for child in &docx.document.children {
+        if let DocumentChild::Section(section) = child {
+            headers.extend(section.property.get_headers());
+        }
+    }
+    headers.sort_by(|left, right| left.0.cmp(&right.0));
+    for (index, (_, header)) in headers.into_iter().enumerate() {
+        let number = index + 1;
+        write_xml(
+            &mut zip,
+            &format!("word/header{number}.xml"),
+            options,
+            header,
+        )?;
+        if let Some(rels) = package.header_rels.get(index) {
+            write_xml(
+                &mut zip,
+                &format!("word/_rels/header{number}.xml.rels"),
+                options,
+                rels,
+            )?;
+        }
+    }
+
+    let mut footers: Vec<&(String, Footer)> = docx.document.section_property.get_footers();
+    for child in &docx.document.children {
+        if let DocumentChild::Section(section) = child {
+            footers.extend(section.property.get_footers());
+        }
+    }
+    footers.sort_by(|left, right| left.0.cmp(&right.0));
+    for (index, (_, footer)) in footers.into_iter().enumerate() {
+        let number = index + 1;
+        write_xml(
+            &mut zip,
+            &format!("word/footer{number}.xml"),
+            options,
+            footer,
+        )?;
+        if let Some(rels) = package.footer_rels.get(index) {
+            write_xml(
+                &mut zip,
+                &format!("word/_rels/footer{number}.xml.rels"),
+                options,
+                rels,
+            )?;
+        }
+    }
+
+    if !package.media.is_empty() {
+        zip.add_directory("word/media/", directory_options)?;
+        for (id, bytes) in package.media {
+            zip.start_file(format!("word/media/{id}.png"), options)?;
+            zip.write_all(&bytes)?;
+        }
+    }
+
+    if let Some(taskpanes) = &docx.taskpanes {
+        zip.add_directory("word/webextensions/", directory_options)?;
+        write_xml(
+            &mut zip,
+            "word/webextensions/taskpanes.xml",
+            options,
+            taskpanes,
+        )?;
+
+        zip.add_directory("word/webextensions/_rels", directory_options)?;
+        write_xml(
+            &mut zip,
+            "word/webextensions/_rels/taskpanes.xml.rels",
+            options,
+            &docx.taskpanes_rels,
+        )?;
+
+        for (index, extension) in docx.web_extensions.iter().enumerate() {
+            write_xml(
+                &mut zip,
+                &format!("word/webextensions/webextension{}.xml", index + 1),
+                options,
+                extension,
+            )?;
+        }
+    }
+
+    if !docx.custom_items.is_empty() {
+        zip.add_directory("customXml/_rels", directory_options)?;
+    }
+    for (index, item) in docx.custom_items.iter().enumerate() {
+        let number = index + 1;
+        write_xml(
+            &mut zip,
+            &format!("customXml/_rels/item{number}.xml.rels"),
+            options,
+            &docx.custom_item_rels[index],
+        )?;
+        write_xml(
+            &mut zip,
+            &format!("customXml/item{number}.xml"),
+            options,
+            item,
+        )?;
+        write_xml(
+            &mut zip,
+            &format!("customXml/itemProps{number}.xml"),
+            options,
+            &docx.custom_item_props[index],
+        )?;
     }
 
     zip.finish()?;


### PR DESCRIPTION
## Summary
- reuse owned strings when XML escaping is unnecessary, avoiding a second allocation across text, styles, fonts, links, and review metadata
- add `Docx::pack` to stream XML package parts directly into the ZIP archive without retaining every rendered XML `Vec<u8>` simultaneously
- share document normalization, relationship, media, TOC, and footnote preparation between buffered and streaming output
- move automatic TOC expansion before paragraph-ID normalization and dependency discovery
- make duplicate paragraph-ID repair terminate deterministically even if an ID generator collides repeatedly
- format boolean, numeric, and enum XML attributes directly into the writer buffer
- fix footer structured-data-tag images using header relationship IDs
- add English Rustdoc for the touched build, packaging, and XML writer APIs and clear existing bare-URL warnings

## Performance
Criterion benchmarks:

- `write_docx_construct` (200 paragraphs × 5 runs): ~426.6 µs → ~330.9 µs (**22.4% faster**)
- direct `Docx::pack` compared with `build().pack()` in the same run: ~2.57 ms → ~1.92 ms (**25% faster**)

The direct packaging path also avoids holding all rendered XML package parts in memory at once. Existing `build()` and `XMLDocx::pack` APIs remain compatible.

## Validation
- direct and buffered packaging produce byte-identical ZIP output, including header/footer images
- `CARGO_INCREMENTAL=0 cargo test --workspace -- --test-threads=1`
- `CARGO_INCREMENTAL=0 cargo test -p docx-rs --lib --no-default-features`
- `CARGO_INCREMENTAL=0 cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- `cargo bench -p docx-rs --bench write_docx --no-run`
