### PR TITLE
Unify document traversal and package media deduplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   automatically generated table-of-contents content is normalized before
   dependency collection.
 - Fix images inside footer structured data tags using header relationship IDs.
+- Deduplicate identical media across the document, header, and footer parts
+  while preserving each part's image relationships. Images and footnotes in
+  nested sections, structured data tags, tables, and tracked content are now
+  collected through one shared document-tree traversal.
 
 ## @0.4.21 (20. Jul, 2026)
 

--- a/docx-core/src/documents/document_tree.rs
+++ b/docx-core/src/documents/document_tree.rs
@@ -1,0 +1,237 @@
+//! Shared traversal for package-relevant nodes in a DOCX document tree.
+//!
+//! Document content can be nested under tables, sections, structured data
+//! tags, hyperlinks, and tracked changes. Centralizing that recursion keeps
+//! dependency collectors complete when new package metadata is added.
+
+use crate::{
+    Delete, DeleteChild, Document, DocumentChild, DrawingData, Footer, FooterChild, Header,
+    HeaderChild, Hyperlink, Insert, InsertChild, MoveFrom, MoveFromChild, MoveTo, MoveToChild,
+    Paragraph, ParagraphChild, Pic, Run, RunChild, Section, SectionChild, StructuredDataTag,
+    StructuredDataTagChild, Table, TableCellContent, TableChild, TableOfContents, TableRowChild,
+};
+
+/// Receives package-relevant nodes while the document tree is traversed.
+///
+/// Keeping traversal in one module prevents media and relationship collectors
+/// from silently disagreeing about nested containers such as tables, sections,
+/// structured data tags, hyperlinks, and tracked changes. Default hooks make
+/// it possible to collect only the data needed by a particular package part.
+pub(crate) trait DocumentTreeVisitor {
+    /// Visits a paragraph before its children are traversed.
+    fn visit_paragraph(&mut self, _paragraph: &mut Paragraph) {}
+
+    /// Visits a run before its children are traversed.
+    fn visit_run(&mut self, _run: &mut Run) {}
+
+    /// Visits an embedded DrawingML picture.
+    fn visit_picture(&mut self, _picture: &mut Pic) {}
+
+    /// Visits a footnote reference stored in a run.
+    fn visit_footnote_reference(&mut self, _reference: &crate::FootnoteReference) {}
+}
+
+/// Traverses the main document body without crossing into header/footer parts.
+///
+/// Header and footer relationships have their own scopes, so callers must walk
+/// those parts separately with [`visit_header`] and [`visit_footer`].
+pub(crate) fn visit_document(document: &mut Document, visitor: &mut impl DocumentTreeVisitor) {
+    for child in &mut document.children {
+        visit_document_child(child, visitor);
+    }
+}
+
+/// Traverses every package-relevant node in one header part.
+pub(crate) fn visit_header(header: &mut Header, visitor: &mut impl DocumentTreeVisitor) {
+    for child in &mut header.children {
+        match child {
+            HeaderChild::Paragraph(paragraph) => visit_paragraph(paragraph, visitor),
+            HeaderChild::Table(table) => visit_table(table, visitor),
+            HeaderChild::StructuredDataTag(tag) => visit_structured_data_tag(tag, visitor),
+        }
+    }
+}
+
+/// Traverses every package-relevant node in one footer part.
+pub(crate) fn visit_footer(footer: &mut Footer, visitor: &mut impl DocumentTreeVisitor) {
+    for child in &mut footer.children {
+        match child {
+            FooterChild::Paragraph(paragraph) => visit_paragraph(paragraph, visitor),
+            FooterChild::Table(table) => visit_table(table, visitor),
+            FooterChild::StructuredDataTag(tag) => visit_structured_data_tag(tag, visitor),
+        }
+    }
+}
+
+fn visit_document_child(child: &mut DocumentChild, visitor: &mut impl DocumentTreeVisitor) {
+    match child {
+        DocumentChild::Paragraph(paragraph) => visit_paragraph(paragraph, visitor),
+        DocumentChild::Table(table) => visit_table(table, visitor),
+        DocumentChild::StructuredDataTag(tag) => visit_structured_data_tag(tag, visitor),
+        DocumentChild::TableOfContents(toc) => visit_table_of_contents(toc, visitor),
+        DocumentChild::Section(section) => visit_section(section, visitor),
+        DocumentChild::BookmarkStart(_)
+        | DocumentChild::BookmarkEnd(_)
+        | DocumentChild::CommentStart(_)
+        | DocumentChild::CommentEnd(_) => {}
+    }
+}
+
+fn visit_section(section: &mut Section, visitor: &mut impl DocumentTreeVisitor) {
+    for child in &mut section.children {
+        match child {
+            SectionChild::Paragraph(paragraph) => visit_paragraph(paragraph, visitor),
+            SectionChild::Table(table) => visit_table(table, visitor),
+            SectionChild::StructuredDataTag(tag) => visit_structured_data_tag(tag, visitor),
+            SectionChild::TableOfContents(toc) => visit_table_of_contents(toc, visitor),
+            SectionChild::BookmarkStart(_)
+            | SectionChild::BookmarkEnd(_)
+            | SectionChild::CommentStart(_)
+            | SectionChild::CommentEnd(_) => {}
+        }
+    }
+}
+
+fn visit_table(table: &mut Table, visitor: &mut impl DocumentTreeVisitor) {
+    for TableChild::TableRow(row) in &mut table.rows {
+        for TableRowChild::TableCell(cell) in &mut row.cells {
+            for content in &mut cell.children {
+                match content {
+                    TableCellContent::Paragraph(paragraph) => visit_paragraph(paragraph, visitor),
+                    TableCellContent::Table(table) => visit_table(table, visitor),
+                    TableCellContent::StructuredDataTag(tag) => {
+                        visit_structured_data_tag(tag, visitor)
+                    }
+                    TableCellContent::TableOfContents(toc) => visit_table_of_contents(toc, visitor),
+                }
+            }
+        }
+    }
+}
+
+fn visit_table_of_contents(toc: &mut TableOfContents, visitor: &mut impl DocumentTreeVisitor) {
+    for content in toc
+        .before_contents
+        .iter_mut()
+        .chain(toc.after_contents.iter_mut())
+    {
+        match content {
+            crate::TocContent::Paragraph(paragraph) => visit_paragraph(paragraph, visitor),
+            crate::TocContent::Table(table) => visit_table(table, visitor),
+        }
+    }
+}
+
+fn visit_structured_data_tag(tag: &mut StructuredDataTag, visitor: &mut impl DocumentTreeVisitor) {
+    for child in &mut tag.children {
+        match child {
+            StructuredDataTagChild::Run(run) => visit_run(run, visitor),
+            StructuredDataTagChild::Paragraph(paragraph) => visit_paragraph(paragraph, visitor),
+            StructuredDataTagChild::Table(table) => visit_table(table, visitor),
+            StructuredDataTagChild::StructuredDataTag(tag) => {
+                visit_structured_data_tag(tag, visitor)
+            }
+            StructuredDataTagChild::BookmarkStart(_)
+            | StructuredDataTagChild::BookmarkEnd(_)
+            | StructuredDataTagChild::CommentStart(_)
+            | StructuredDataTagChild::CommentEnd(_) => {}
+        }
+    }
+}
+
+fn visit_paragraph(paragraph: &mut Paragraph, visitor: &mut impl DocumentTreeVisitor) {
+    visitor.visit_paragraph(paragraph);
+    visit_paragraph_children(&mut paragraph.children, visitor);
+}
+
+fn visit_paragraph_children(
+    children: &mut [ParagraphChild],
+    visitor: &mut impl DocumentTreeVisitor,
+) {
+    for child in children {
+        match child {
+            ParagraphChild::Run(run) => visit_run(run, visitor),
+            ParagraphChild::Insert(insert) => visit_insert(insert, visitor),
+            ParagraphChild::Delete(delete) => visit_delete(delete, visitor),
+            ParagraphChild::MoveFrom(moved) => visit_move_from(moved, visitor),
+            ParagraphChild::MoveTo(moved) => visit_move_to(moved, visitor),
+            ParagraphChild::Hyperlink(link) => visit_hyperlink(link, visitor),
+            ParagraphChild::StructuredDataTag(tag) => visit_structured_data_tag(tag, visitor),
+            ParagraphChild::BookmarkStart(_)
+            | ParagraphChild::BookmarkEnd(_)
+            | ParagraphChild::CommentStart(_)
+            | ParagraphChild::CommentEnd(_)
+            | ParagraphChild::PageNum(_)
+            | ParagraphChild::NumPages(_) => {}
+        }
+    }
+}
+
+fn visit_hyperlink(link: &mut Hyperlink, visitor: &mut impl DocumentTreeVisitor) {
+    visit_paragraph_children(&mut link.children, visitor);
+}
+
+fn visit_insert(insert: &mut Insert, visitor: &mut impl DocumentTreeVisitor) {
+    for child in &mut insert.children {
+        match child {
+            InsertChild::Run(run) => visit_run(run, visitor),
+            InsertChild::Delete(delete) => visit_delete(delete, visitor),
+            InsertChild::CommentStart(_) | InsertChild::CommentEnd(_) => {}
+        }
+    }
+}
+
+fn visit_delete(delete: &mut Delete, visitor: &mut impl DocumentTreeVisitor) {
+    for child in &mut delete.children {
+        if let DeleteChild::Run(run) = child {
+            visit_run(run, visitor);
+        }
+    }
+}
+
+fn visit_move_from(moved: &mut MoveFrom, visitor: &mut impl DocumentTreeVisitor) {
+    for child in &mut moved.children {
+        if let MoveFromChild::Run(run) = child {
+            visit_run(run, visitor);
+        }
+    }
+}
+
+fn visit_move_to(moved: &mut MoveTo, visitor: &mut impl DocumentTreeVisitor) {
+    for child in &mut moved.children {
+        match child {
+            MoveToChild::Run(run) => visit_run(run, visitor),
+            MoveToChild::Delete(delete) => visit_delete(delete, visitor),
+            MoveToChild::CommentStart(_) | MoveToChild::CommentEnd(_) => {}
+        }
+    }
+}
+
+fn visit_run(run: &mut Run, visitor: &mut impl DocumentTreeVisitor) {
+    visitor.visit_run(run);
+    for child in &mut run.children {
+        match child {
+            RunChild::Drawing(drawing) => {
+                if let Some(DrawingData::Pic(picture)) = &mut drawing.data {
+                    visitor.visit_picture(picture);
+                }
+            }
+            RunChild::FootnoteReference(reference) => visitor.visit_footnote_reference(reference),
+            RunChild::Text(_)
+            | RunChild::Sym(_)
+            | RunChild::DeleteText(_)
+            | RunChild::Tab(_)
+            | RunChild::PTab(_)
+            | RunChild::Break(_)
+            | RunChild::CarriageReturn(_)
+            | RunChild::Shape(_)
+            | RunChild::CommentStart(_)
+            | RunChild::CommentEnd(_)
+            | RunChild::FieldChar(_)
+            | RunChild::InstrText(_)
+            | RunChild::DeleteInstrText(_)
+            | RunChild::InstrTextString(_)
+            | RunChild::Shading(_) => {}
+        }
+    }
+}

--- a/docx-core/src/documents/image_collector.rs
+++ b/docx-core/src/documents/image_collector.rs
@@ -1,260 +1,253 @@
-use crate::{
-    DeleteChild, DrawingData, InsertChild, Paragraph, ParagraphChild, Pic, RunChild,
-    StructuredDataTagChild, Table, TableCellContent, TableChild, TableRowChild, TocContent,
-};
-use std::collections::HashMap;
+//! Collects image relationships, physical media, and footnotes for packaging.
+//!
+//! OPC relationships belong to individual XML parts, but media files belong
+//! to the whole package. This module models those scopes separately so shared
+//! image bytes are written once without losing any part-local relationship.
 
+use std::collections::{HashMap, HashSet};
+
+use super::document_tree::{visit_document, visit_footer, visit_header, DocumentTreeVisitor};
+use crate::{
+    Document, Footer, Footnote, FootnoteReference, Header, ImageIdAndBuf, ImageIdAndPath, Pic,
+};
+
+/// Stores physical media once for the entire OPC package.
+///
+/// Relationship IDs are scoped to individual XML parts, while files under
+/// `word/media` are package-global. Keeping those concepts separate allows a
+/// body, header, and footer to reference the same bytes without writing three
+/// copies or dropping a relationship from one of the parts.
 #[derive(Default)]
-pub(crate) struct ImageDeduplicator {
-    by_id: HashMap<String, usize>,
+pub(crate) struct MediaRegistry {
+    media: Vec<ImageIdAndBuf>,
+    media_ids: HashSet<String>,
     by_fingerprint: HashMap<(usize, u32), Vec<usize>>,
 }
 
-fn collect_pic(
-    pic: &mut Pic,
-    images: &mut Vec<(String, String)>,
-    image_bufs: &mut Vec<(String, Vec<u8>)>,
-    id_prefix: Option<&str>,
-    deduplicator: &mut ImageDeduplicator,
-) {
-    let image = std::mem::take(&mut pic.image);
+impl MediaRegistry {
+    /// Registers physical bytes and returns the package-global media ID.
+    fn register(&mut self, preferred_id: &str, bytes: Vec<u8>) -> String {
+        let fingerprint = (bytes.len(), crc32fast::hash(&bytes));
+        if let Some(index) = self
+            .by_fingerprint
+            .get(&fingerprint)
+            .and_then(|candidates| {
+                candidates
+                    .iter()
+                    .copied()
+                    .find(|index| self.media[*index].1 == bytes)
+            })
+        {
+            return self.media[index].0.clone();
+        }
 
-    if let Some(index) = deduplicator.by_id.get(&pic.id).copied() {
-        pic.id = image_bufs[index].0.clone();
-        return;
+        let media_id = self.unique_media_id(preferred_id);
+        let index = self.media.len();
+        self.media.push((media_id.clone(), bytes));
+        self.media_ids.insert(media_id.clone());
+        self.by_fingerprint
+            .entry(fingerprint)
+            .or_default()
+            .push(index);
+        media_id
     }
 
-    let fingerprint = (image.len(), crc32fast::hash(&image));
-    if let Some(index) = deduplicator
-        .by_fingerprint
-        .get(&fingerprint)
-        .and_then(|candidates| {
-            candidates
-                .iter()
-                .copied()
-                .find(|index| image_bufs[*index].1 == image)
-        })
-    {
-        pic.id = image_bufs[index].0.clone();
-        return;
+    /// Consumes the registry and returns files ready for ZIP packaging.
+    pub(crate) fn into_media(self) -> Vec<ImageIdAndBuf> {
+        self.media
     }
 
-    let pic_id = if let Some(prefix) = id_prefix {
-        format!("{prefix}{}", pic.id)
-    } else {
-        pic.id.clone()
-    };
-    images.push((pic_id.clone(), format!("media/{pic_id}.png")));
-    let index = image_bufs.len();
-    image_bufs.push((pic_id.clone(), image));
-    deduplicator.by_id.insert(pic_id.clone(), index);
-    deduplicator
-        .by_fingerprint
-        .entry(fingerprint)
-        .or_default()
-        .push(index);
-    pic.id = pic_id;
+    fn unique_media_id(&self, preferred_id: &str) -> String {
+        if !self.media_ids.contains(preferred_id) {
+            return preferred_id.to_owned();
+        }
+
+        (2usize..)
+            .map(|suffix| format!("{preferred_id}_{suffix}"))
+            .find(|candidate| !self.media_ids.contains(candidate))
+            .expect("the media ID space should not be exhausted")
+    }
 }
 
-pub(crate) fn collect_images_from_paragraph(
-    paragraph: &mut Paragraph,
-    images: &mut Vec<(String, String)>,
-    image_bufs: &mut Vec<(String, Vec<u8>)>,
-    id_prefix: Option<&str>,
-    deduplicator: &mut ImageDeduplicator,
-) {
-    for child in &mut paragraph.children {
-        if let ParagraphChild::Run(run) = child {
-            for child in &mut run.children {
-                if let RunChild::Drawing(d) = child {
-                    if let Some(DrawingData::Pic(pic)) = &mut d.data {
-                        collect_pic(pic, images, image_bufs, id_prefix, deduplicator);
-                    }
-                }
-            }
-        } else if let ParagraphChild::Insert(ins) = child {
-            for child in &mut ins.children {
-                match child {
-                    InsertChild::Run(run) => {
-                        for child in &mut run.children {
-                            if let RunChild::Drawing(d) = child {
-                                if let Some(DrawingData::Pic(pic)) = &mut d.data {
-                                    collect_pic(pic, images, image_bufs, id_prefix, deduplicator);
-                                }
-                            }
-                        }
-                    }
-                    InsertChild::Delete(del) => {
-                        for d in &mut del.children {
-                            if let DeleteChild::Run(run) = d {
-                                for child in &mut run.children {
-                                    if let RunChild::Drawing(d) = child {
-                                        if let Some(DrawingData::Pic(pic)) = &mut d.data {
-                                            collect_pic(
-                                                pic,
-                                                images,
-                                                image_bufs,
-                                                id_prefix,
-                                                deduplicator,
-                                            );
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    _ => {}
-                }
-            }
-        } else if let ParagraphChild::Delete(del) = child {
-            for d in &mut del.children {
-                if let DeleteChild::Run(run) = d {
-                    for child in &mut run.children {
-                        if let RunChild::Drawing(d) = child {
-                            if let Some(DrawingData::Pic(pic)) = &mut d.data {
-                                collect_pic(pic, images, image_bufs, id_prefix, deduplicator);
-                            }
-                        }
-                    }
-                }
-            }
+/// Data collected from one relationship scope during a tree walk.
+pub(crate) struct CollectedPart {
+    pub(crate) relationships: Vec<ImageIdAndPath>,
+    pub(crate) footnotes: Vec<Footnote>,
+}
+
+/// Collects media relationships and footnotes while visiting one XML part.
+///
+/// A fresh collector is created for each relationship scope, but every
+/// collector shares one [`MediaRegistry`]. This is the key distinction that
+/// preserves per-part relationships while deduplicating physical media.
+struct PackagePartCollector<'a> {
+    registry: &'a mut MediaRegistry,
+    relationship_prefix: Option<&'a str>,
+    relationships: Vec<ImageIdAndPath>,
+    relationship_ids: HashSet<String>,
+    relationships_by_target: HashMap<String, String>,
+    footnotes: Vec<Footnote>,
+}
+
+impl<'a> PackagePartCollector<'a> {
+    fn new(registry: &'a mut MediaRegistry, relationship_prefix: Option<&'a str>) -> Self {
+        Self {
+            registry,
+            relationship_prefix,
+            relationships: Vec::new(),
+            relationship_ids: HashSet::new(),
+            relationships_by_target: HashMap::new(),
+            footnotes: Vec::new(),
+        }
+    }
+
+    fn finish(self) -> CollectedPart {
+        CollectedPart {
+            relationships: self.relationships,
+            footnotes: self.footnotes,
+        }
+    }
+
+    fn relationship_id(&self, picture_id: &str) -> String {
+        match self.relationship_prefix {
+            Some(prefix) => format!("{prefix}{picture_id}"),
+            None => picture_id.to_owned(),
+        }
+    }
+
+    /// Returns an ID that is unique inside this part's relationship scope.
+    fn unique_relationship_id(&self, preferred_id: &str) -> String {
+        match self.relationship_ids.contains(preferred_id) {
+            false => preferred_id.to_owned(),
+            true => (2usize..)
+                .map(|suffix| format!("{preferred_id}_{suffix}"))
+                .find(|candidate| !self.relationship_ids.contains(candidate))
+                .expect("the relationship ID space should not be exhausted"),
         }
     }
 }
 
-pub(crate) fn collect_images_from_table(
-    table: &mut Table,
-    images: &mut Vec<(String, String)>,
-    image_bufs: &mut Vec<(String, Vec<u8>)>,
-    id_prefix: Option<&str>,
-    deduplicator: &mut ImageDeduplicator,
-) {
-    for TableChild::TableRow(row) in &mut table.rows {
-        for TableRowChild::TableCell(cell) in &mut row.cells {
-            for content in &mut cell.children {
-                match content {
-                    TableCellContent::Paragraph(paragraph) => {
-                        collect_images_from_paragraph(
-                            paragraph,
-                            images,
-                            image_bufs,
-                            id_prefix,
-                            deduplicator,
-                        );
-                    }
-                    TableCellContent::Table(table) => collect_images_from_table(
-                        table,
-                        images,
-                        image_bufs,
-                        id_prefix,
-                        deduplicator,
-                    ),
-                    TableCellContent::StructuredDataTag(tag) => {
-                        for child in &mut tag.children {
-                            if let StructuredDataTagChild::Paragraph(paragraph) = child {
-                                collect_images_from_paragraph(
-                                    paragraph,
-                                    images,
-                                    image_bufs,
-                                    id_prefix,
-                                    deduplicator,
-                                );
-                            }
-                            if let StructuredDataTagChild::Table(table) = child {
-                                collect_images_from_table(
-                                    table,
-                                    images,
-                                    image_bufs,
-                                    id_prefix,
-                                    deduplicator,
-                                );
-                            }
-                        }
-                    }
-                    TableCellContent::TableOfContents(t) => {
-                        for child in &mut t.before_contents {
-                            if let TocContent::Paragraph(paragraph) = child {
-                                collect_images_from_paragraph(
-                                    paragraph,
-                                    images,
-                                    image_bufs,
-                                    id_prefix,
-                                    deduplicator,
-                                );
-                            }
-                            if let TocContent::Table(table) = child {
-                                collect_images_from_table(
-                                    table,
-                                    images,
-                                    image_bufs,
-                                    id_prefix,
-                                    deduplicator,
-                                );
-                            }
-                        }
+impl DocumentTreeVisitor for PackagePartCollector<'_> {
+    fn visit_picture(&mut self, picture: &mut Pic) {
+        let preferred_relationship_id = self.relationship_id(&picture.id);
+        let media_id = self.registry.register(
+            &preferred_relationship_id,
+            std::mem::take(&mut picture.image),
+        );
+        let target = format!("media/{media_id}.png");
 
-                        for child in &mut t.after_contents {
-                            if let TocContent::Paragraph(paragraph) = child {
-                                collect_images_from_paragraph(
-                                    paragraph,
-                                    images,
-                                    image_bufs,
-                                    id_prefix,
-                                    deduplicator,
-                                );
-                            }
-                            if let TocContent::Table(table) = child {
-                                collect_images_from_table(
-                                    table,
-                                    images,
-                                    image_bufs,
-                                    id_prefix,
-                                    deduplicator,
-                                );
-                            }
-                        }
-                    }
-                }
-            }
+        if let Some(relationship_id) = self.relationships_by_target.get(&target) {
+            picture.id.clone_from(relationship_id);
+            return;
+        }
+
+        let relationship_id = self.unique_relationship_id(&preferred_relationship_id);
+        self.relationship_ids.insert(relationship_id.clone());
+        self.relationships_by_target
+            .insert(target.clone(), relationship_id.clone());
+        self.relationships.push((relationship_id.clone(), target));
+        picture.id = relationship_id;
+    }
+
+    fn visit_footnote_reference(&mut self, reference: &FootnoteReference) {
+        self.footnotes.push(reference.into());
+    }
+}
+
+/// Collects package data from the complete main document tree in one pass.
+pub(crate) fn collect_document_part(
+    document: &mut Document,
+    registry: &mut MediaRegistry,
+) -> CollectedPart {
+    let mut collector = PackagePartCollector::new(registry, None);
+    visit_document(document, &mut collector);
+    collector.finish()
+}
+
+/// Collects footnotes without consuming image buffers from the document tree.
+///
+/// This separate visitor keeps [`crate::Docx::collect_footnotes`] compatible
+/// for callers that invoke it directly. Package preparation uses
+/// [`collect_document_part`] so images and footnotes are normally gathered in
+/// one traversal.
+pub(crate) fn collect_document_footnotes(document: &mut Document) -> Vec<Footnote> {
+    #[derive(Default)]
+    struct FootnoteCollector {
+        footnotes: Vec<Footnote>,
+    }
+
+    impl DocumentTreeVisitor for FootnoteCollector {
+        fn visit_footnote_reference(&mut self, reference: &FootnoteReference) {
+            self.footnotes.push(reference.into());
         }
     }
+
+    let mut collector = FootnoteCollector::default();
+    visit_document(document, &mut collector);
+    collector.footnotes
+}
+
+/// Collects package data from one header relationship scope.
+pub(crate) fn collect_header_part(
+    header: &mut Header,
+    registry: &mut MediaRegistry,
+) -> CollectedPart {
+    let mut collector = PackagePartCollector::new(registry, Some("header"));
+    visit_header(header, &mut collector);
+    collector.finish()
+}
+
+/// Collects package data from one footer relationship scope.
+pub(crate) fn collect_footer_part(
+    footer: &mut Footer,
+    registry: &mut MediaRegistry,
+) -> CollectedPart {
+    let mut collector = PackagePartCollector::new(registry, Some("footer"));
+    visit_footer(footer, &mut collector);
+    collector.finish()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::Run;
 
     #[test]
-    fn deduplicates_identical_images_across_paragraphs() {
-        let image = vec![1, 2, 3, 4, 5];
-        let mut first = Paragraph::new().add_run(Run::new().add_image(Pic::new_with_dimensions(
-            image.clone(),
-            1,
-            1,
-        )));
-        let mut second =
-            Paragraph::new().add_run(Run::new().add_image(Pic::new_with_dimensions(image, 1, 1)));
-        let mut images = Vec::new();
-        let mut image_bufs = Vec::new();
-        let mut deduplicator = ImageDeduplicator::default();
-
-        collect_images_from_paragraph(
-            &mut first,
-            &mut images,
-            &mut image_bufs,
-            None,
-            &mut deduplicator,
+    fn registry_deduplicates_identical_media_but_keeps_part_relationships() {
+        let bytes = vec![1, 2, 3, 4, 5];
+        let mut first =
+            Header::new().add_paragraph(crate::Paragraph::new().add_run(
+                crate::Run::new().add_image(Pic::new_with_dimensions(bytes.clone(), 1, 1)),
+            ));
+        let mut second = Header::new().add_paragraph(
+            crate::Paragraph::new()
+                .add_run(crate::Run::new().add_image(Pic::new_with_dimensions(bytes, 1, 1))),
         );
-        collect_images_from_paragraph(
-            &mut second,
-            &mut images,
-            &mut image_bufs,
-            None,
-            &mut deduplicator,
-        );
+        let mut registry = MediaRegistry::default();
 
-        assert_eq!(images.len(), 1);
-        assert_eq!(image_bufs.len(), 1);
+        let first = collect_header_part(&mut first, &mut registry);
+        let second = collect_header_part(&mut second, &mut registry);
+
+        assert_eq!(registry.media.len(), 1);
+        assert_eq!(first.relationships.len(), 1);
+        assert_eq!(second.relationships.len(), 1);
+        assert_eq!(first.relationships[0].1, second.relationships[0].1);
+    }
+
+    #[test]
+    fn identical_media_reuses_one_relationship_within_a_part() {
+        let bytes = vec![9, 8, 7, 6];
+        let mut first = Pic::new_with_dimensions(bytes.clone(), 1, 1);
+        first.id = "first".to_owned();
+        let mut second = Pic::new_with_dimensions(bytes, 1, 1);
+        second.id = "second".to_owned();
+        let mut document = Document::new()
+            .add_paragraph(crate::Paragraph::new().add_run(crate::Run::new().add_image(first)))
+            .add_paragraph(crate::Paragraph::new().add_run(crate::Run::new().add_image(second)));
+        let mut registry = MediaRegistry::default();
+
+        let part = collect_document_part(&mut document, &mut registry);
+
+        assert_eq!(registry.media.len(), 1);
+        assert_eq!(part.relationships.len(), 1);
     }
 }

--- a/docx-core/src/documents/mod.rs
+++ b/docx-core/src/documents/mod.rs
@@ -14,6 +14,7 @@ mod custom_item_rels;
 mod doc_props;
 mod document;
 mod document_rels;
+mod document_tree;
 mod elements;
 mod font_table;
 mod footer;
@@ -85,7 +86,8 @@ use base64::Engine;
 use serde::{ser, Serialize};
 
 use self::image_collector::{
-    collect_images_from_paragraph, collect_images_from_table, ImageDeduplicator,
+    collect_document_footnotes, collect_document_part, collect_footer_part, collect_header_part,
+    MediaRegistry,
 };
 
 #[derive(Debug, Clone)]
@@ -914,12 +916,11 @@ impl Docx {
     fn prepare_package(&mut self) -> PackageMetadata {
         let has_toc = self.prepare_for_build();
 
-        let (images, mut media) = self.images_in_doc();
-        let (header_images, header_media) = self.images_in_header();
-        let (footer_images, footer_media) = self.images_in_footer();
-        media.extend(header_media);
-        media.extend(footer_media);
-        self.document_rels.images = images;
+        let mut media = MediaRegistry::default();
+        let document_part = collect_document_part(&mut self.document, &mut media);
+        let header_images = self.collect_header_images(&mut media);
+        let footer_images = self.collect_footer_images(&mut media);
+        self.document_rels.images = document_part.relationships;
 
         let mut header_rels = vec![HeaderRels::new(); 3];
         for (rels, images) in header_rels.iter_mut().zip(header_images) {
@@ -931,7 +932,8 @@ impl Docx {
             rels.set_images(images);
         }
 
-        if self.collect_footnotes() {
+        if !document_part.footnotes.is_empty() {
+            self.footnotes.add(document_part.footnotes);
             self.content_type = std::mem::take(&mut self.content_type).add_footnotes();
             self.document_rels.has_footnotes = true;
         }
@@ -951,7 +953,7 @@ impl Docx {
         }
 
         PackageMetadata {
-            media,
+            media: media.into_media(),
             header_rels,
             footer_rels,
         }
@@ -1275,369 +1277,55 @@ impl Docx {
         }
     }
 
-    // Traverse and collect images from document.
-    fn images_in_doc(&mut self) -> (Vec<ImageIdAndPath>, Vec<ImageIdAndBuf>) {
-        let mut images: Vec<(String, String)> = vec![];
-        let mut image_bufs: Vec<(String, Vec<u8>)> = vec![];
-        let mut deduplicator = ImageDeduplicator::default();
+    /// Collects image relationships for the default, first, and even headers.
+    ///
+    /// Each entry deliberately uses a separate relationship scope while all
+    /// entries share the package-wide media registry. This preserves valid
+    /// header `.rels` files without storing duplicate image bytes.
+    fn collect_header_images(&mut self, media: &mut MediaRegistry) -> Vec<Vec<ImageIdAndPath>> {
+        let mut images = vec![Vec::new(); 3];
+        let headers = [
+            &mut self.document.section_property.header,
+            &mut self.document.section_property.first_header,
+            &mut self.document.section_property.even_header,
+        ];
 
-        for child in &mut self.document.children {
-            match child {
-                DocumentChild::Paragraph(paragraph) => {
-                    collect_images_from_paragraph(
-                        paragraph,
-                        &mut images,
-                        &mut image_bufs,
-                        None,
-                        &mut deduplicator,
-                    );
-                }
-                DocumentChild::Table(table) => {
-                    collect_images_from_table(
-                        table,
-                        &mut images,
-                        &mut image_bufs,
-                        None,
-                        &mut deduplicator,
-                    );
-                }
-                _ => {}
+        for (images, header) in images.iter_mut().zip(headers) {
+            if let Some((_, header)) = header.as_mut() {
+                *images = collect_header_part(header, media).relationships;
             }
         }
-        (images, image_bufs)
+        images
     }
 
-    fn images_in_header(&mut self) -> (Vec<Vec<ImageIdAndPath>>, Vec<ImageIdAndBuf>) {
-        let mut header_images: Vec<Vec<ImageIdAndPath>> = vec![vec![]; 3];
-        let mut image_bufs: Vec<(String, Vec<u8>)> = vec![];
-        let mut deduplicator = ImageDeduplicator::default();
+    /// Collects image relationships for the default, first, and even footers.
+    ///
+    /// The fixed order matches the package writer's footer part ordering. A
+    /// shared registry prevents repeated footer and body images from being
+    /// emitted as separate physical media files.
+    fn collect_footer_images(&mut self, media: &mut MediaRegistry) -> Vec<Vec<ImageIdAndPath>> {
+        let mut images = vec![Vec::new(); 3];
+        let footers = [
+            &mut self.document.section_property.footer,
+            &mut self.document.section_property.first_footer,
+            &mut self.document.section_property.even_footer,
+        ];
 
-        if let Some((_, header)) = &mut self.document.section_property.header.as_mut() {
-            let mut images: Vec<ImageIdAndPath> = vec![];
-            for child in header.children.iter_mut() {
-                match child {
-                    HeaderChild::Paragraph(paragraph) => {
-                        collect_images_from_paragraph(
-                            paragraph,
-                            &mut images,
-                            &mut image_bufs,
-                            Some("header"),
-                            &mut deduplicator,
-                        );
-                    }
-                    HeaderChild::Table(table) => {
-                        collect_images_from_table(
-                            table,
-                            &mut images,
-                            &mut image_bufs,
-                            Some("header"),
-                            &mut deduplicator,
-                        );
-                    }
-                    HeaderChild::StructuredDataTag(tag) => {
-                        for child in tag.children.iter_mut() {
-                            if let StructuredDataTagChild::Paragraph(paragraph) = child {
-                                collect_images_from_paragraph(
-                                    paragraph,
-                                    &mut images,
-                                    &mut image_bufs,
-                                    Some("header"),
-                                    &mut deduplicator,
-                                );
-                            }
-                            if let StructuredDataTagChild::Table(table) = child {
-                                collect_images_from_table(
-                                    table,
-                                    &mut images,
-                                    &mut image_bufs,
-                                    Some("header"),
-                                    &mut deduplicator,
-                                );
-                            }
-                        }
-                    }
-                }
+        for (images, footer) in images.iter_mut().zip(footers) {
+            if let Some((_, footer)) = footer.as_mut() {
+                *images = collect_footer_part(footer, media).relationships;
             }
-            header_images[0] = images;
         }
-
-        if let Some((_, header)) = &mut self.document.section_property.first_header.as_mut() {
-            let mut images: Vec<ImageIdAndPath> = vec![];
-            for child in header.children.iter_mut() {
-                match child {
-                    HeaderChild::Paragraph(paragraph) => {
-                        collect_images_from_paragraph(
-                            paragraph,
-                            &mut images,
-                            &mut image_bufs,
-                            Some("header"),
-                            &mut deduplicator,
-                        );
-                    }
-                    HeaderChild::Table(table) => {
-                        collect_images_from_table(
-                            table,
-                            &mut images,
-                            &mut image_bufs,
-                            Some("header"),
-                            &mut deduplicator,
-                        );
-                    }
-                    HeaderChild::StructuredDataTag(tag) => {
-                        for child in tag.children.iter_mut() {
-                            if let StructuredDataTagChild::Paragraph(paragraph) = child {
-                                collect_images_from_paragraph(
-                                    paragraph,
-                                    &mut images,
-                                    &mut image_bufs,
-                                    Some("header"),
-                                    &mut deduplicator,
-                                );
-                            }
-                            if let StructuredDataTagChild::Table(table) = child {
-                                collect_images_from_table(
-                                    table,
-                                    &mut images,
-                                    &mut image_bufs,
-                                    Some("header"),
-                                    &mut deduplicator,
-                                );
-                            }
-                        }
-                    }
-                }
-            }
-            header_images[1] = images;
-        }
-
-        if let Some((_, header)) = &mut self.document.section_property.even_header.as_mut() {
-            let mut images: Vec<ImageIdAndPath> = vec![];
-            for child in header.children.iter_mut() {
-                match child {
-                    HeaderChild::Paragraph(paragraph) => {
-                        collect_images_from_paragraph(
-                            paragraph,
-                            &mut images,
-                            &mut image_bufs,
-                            Some("header"),
-                            &mut deduplicator,
-                        );
-                    }
-                    HeaderChild::Table(table) => {
-                        collect_images_from_table(
-                            table,
-                            &mut images,
-                            &mut image_bufs,
-                            Some("header"),
-                            &mut deduplicator,
-                        );
-                    }
-                    HeaderChild::StructuredDataTag(tag) => {
-                        for child in tag.children.iter_mut() {
-                            if let StructuredDataTagChild::Paragraph(paragraph) = child {
-                                collect_images_from_paragraph(
-                                    paragraph,
-                                    &mut images,
-                                    &mut image_bufs,
-                                    Some("header"),
-                                    &mut deduplicator,
-                                );
-                            }
-                            if let StructuredDataTagChild::Table(table) = child {
-                                collect_images_from_table(
-                                    table,
-                                    &mut images,
-                                    &mut image_bufs,
-                                    Some("header"),
-                                    &mut deduplicator,
-                                );
-                            }
-                        }
-                    }
-                }
-            }
-            header_images[2] = images;
-        }
-        (header_images, image_bufs)
+        images
     }
 
-    // Traverse and collect images from header.
-    fn images_in_footer(&mut self) -> (Vec<Vec<ImageIdAndPath>>, Vec<ImageIdAndBuf>) {
-        let mut footer_images: Vec<Vec<ImageIdAndPath>> = vec![vec![]; 3];
-        let mut image_bufs: Vec<(String, Vec<u8>)> = vec![];
-        let mut deduplicator = ImageDeduplicator::default();
-
-        if let Some((_, footer)) = &mut self.document.section_property.footer.as_mut() {
-            let mut images: Vec<ImageIdAndPath> = vec![];
-            for child in footer.children.iter_mut() {
-                match child {
-                    FooterChild::Paragraph(paragraph) => {
-                        collect_images_from_paragraph(
-                            paragraph,
-                            &mut images,
-                            &mut image_bufs,
-                            Some("footer"),
-                            &mut deduplicator,
-                        );
-                    }
-                    FooterChild::Table(table) => {
-                        collect_images_from_table(
-                            table,
-                            &mut images,
-                            &mut image_bufs,
-                            Some("footer"),
-                            &mut deduplicator,
-                        );
-                    }
-                    FooterChild::StructuredDataTag(tag) => {
-                        for child in tag.children.iter_mut() {
-                            if let StructuredDataTagChild::Paragraph(paragraph) = child {
-                                collect_images_from_paragraph(
-                                    paragraph,
-                                    &mut images,
-                                    &mut image_bufs,
-                                    Some("footer"),
-                                    &mut deduplicator,
-                                );
-                            }
-                            if let StructuredDataTagChild::Table(table) = child {
-                                collect_images_from_table(
-                                    table,
-                                    &mut images,
-                                    &mut image_bufs,
-                                    Some("footer"),
-                                    &mut deduplicator,
-                                );
-                            }
-                        }
-                    }
-                }
-            }
-            footer_images[0] = images;
-        }
-
-        if let Some((_, footer)) = &mut self.document.section_property.first_footer.as_mut() {
-            let mut images: Vec<ImageIdAndPath> = vec![];
-            for child in footer.children.iter_mut() {
-                match child {
-                    FooterChild::Paragraph(paragraph) => {
-                        collect_images_from_paragraph(
-                            paragraph,
-                            &mut images,
-                            &mut image_bufs,
-                            Some("footer"),
-                            &mut deduplicator,
-                        );
-                    }
-                    FooterChild::Table(table) => {
-                        collect_images_from_table(
-                            table,
-                            &mut images,
-                            &mut image_bufs,
-                            Some("footer"),
-                            &mut deduplicator,
-                        );
-                    }
-                    FooterChild::StructuredDataTag(tag) => {
-                        for child in tag.children.iter_mut() {
-                            if let StructuredDataTagChild::Paragraph(paragraph) = child {
-                                collect_images_from_paragraph(
-                                    paragraph,
-                                    &mut images,
-                                    &mut image_bufs,
-                                    Some("footer"),
-                                    &mut deduplicator,
-                                );
-                            }
-                            if let StructuredDataTagChild::Table(table) = child {
-                                collect_images_from_table(
-                                    table,
-                                    &mut images,
-                                    &mut image_bufs,
-                                    Some("footer"),
-                                    &mut deduplicator,
-                                );
-                            }
-                        }
-                    }
-                }
-            }
-            footer_images[1] = images;
-        }
-
-        if let Some((_, footer)) = &mut self.document.section_property.even_footer.as_mut() {
-            let mut images: Vec<ImageIdAndPath> = vec![];
-            for child in footer.children.iter_mut() {
-                match child {
-                    FooterChild::Paragraph(paragraph) => {
-                        collect_images_from_paragraph(
-                            paragraph,
-                            &mut images,
-                            &mut image_bufs,
-                            Some("footer"),
-                            &mut deduplicator,
-                        );
-                    }
-                    FooterChild::Table(table) => {
-                        collect_images_from_table(
-                            table,
-                            &mut images,
-                            &mut image_bufs,
-                            Some("footer"),
-                            &mut deduplicator,
-                        );
-                    }
-                    FooterChild::StructuredDataTag(tag) => {
-                        for child in tag.children.iter_mut() {
-                            if let StructuredDataTagChild::Paragraph(paragraph) = child {
-                                collect_images_from_paragraph(
-                                    paragraph,
-                                    &mut images,
-                                    &mut image_bufs,
-                                    Some("footer"),
-                                    &mut deduplicator,
-                                );
-                            }
-                            if let StructuredDataTagChild::Table(table) = child {
-                                collect_images_from_table(
-                                    table,
-                                    &mut images,
-                                    &mut image_bufs,
-                                    Some("footer"),
-                                    &mut deduplicator,
-                                );
-                            }
-                        }
-                    }
-                }
-            }
-            footer_images[2] = images;
-        }
-        (footer_images, image_bufs)
-    }
-
-    /// Collect footnotes from all Runs to the docx footnotes node.
+    /// Collects footnote references from the complete main document tree.
+    ///
+    /// This method remains available for callers that collect dependencies
+    /// explicitly. Normal package builds collect footnotes together with
+    /// images, avoiding a second traversal of the document tree.
     pub fn collect_footnotes(&mut self) -> bool {
-        let footnotes: Vec<Footnote> = self
-            .document
-            .children
-            .iter()
-            .filter_map(|child| match child {
-                DocumentChild::Paragraph(paragraph) => Some(&paragraph.children),
-                _ => None,
-            })
-            .flat_map(|children| children.iter())
-            .filter_map(|para_child| match para_child {
-                ParagraphChild::Run(run) => Some(&run.children),
-                _ => None,
-            })
-            .flat_map(|children| children.iter())
-            .filter_map(|run_child| match run_child {
-                RunChild::FootnoteReference(footnote_ref) => Some(footnote_ref),
-                _ => None,
-            })
-            .map(Into::<Footnote>::into)
-            .collect();
+        let footnotes = collect_document_footnotes(&mut self.document);
         let is_footnotes = !footnotes.is_empty();
         self.footnotes.add(footnotes);
         is_footnotes
@@ -2639,6 +2327,16 @@ fn update_document_by_toc(
 mod image_collection_tests {
     use super::*;
 
+    fn picture(id: &str, bytes: Vec<u8>) -> Pic {
+        let mut picture = Pic::new_with_dimensions(bytes, 1, 1);
+        picture.id = id.to_owned();
+        picture
+    }
+
+    fn image_paragraph(id: &str, bytes: Vec<u8>) -> Paragraph {
+        Paragraph::new().add_run(Run::new().add_image(picture(id, bytes)))
+    }
+
     #[test]
     fn structured_footer_images_use_footer_relationship_ids() {
         let tag = StructuredDataTag::new().add_paragraph(
@@ -2649,12 +2347,75 @@ mod image_collection_tests {
             ))),
         );
         let footer = Footer::new().add_structured_data_tag(tag);
-        let mut docx = Docx::new().footer(footer);
+        let xml = Docx::new().footer(footer).build();
 
-        let (relationships, media) = docx.images_in_footer();
+        assert!(String::from_utf8_lossy(&xml.footer_rels[0]).contains("Id=\"footer"));
+        assert!(xml.media[0].0.starts_with("footer"));
+    }
 
-        assert!(relationships[0][0].0.starts_with("footer"));
-        assert!(media[0].0.starts_with("footer"));
+    #[test]
+    fn repeated_header_images_keep_relationships_in_each_part() {
+        let bytes = vec![1, 2, 3, 4];
+        let xml = Docx::new()
+            .header(Header::new().add_paragraph(image_paragraph("default", bytes.clone())))
+            .first_header(Header::new().add_paragraph(image_paragraph("first", bytes)))
+            .build();
+
+        assert_eq!(xml.media.len(), 1);
+        assert!(String::from_utf8_lossy(&xml.header_rels[0]).contains("relationships/image"));
+        assert!(String::from_utf8_lossy(&xml.header_rels[1]).contains("relationships/image"));
+    }
+
+    #[test]
+    fn repeated_images_share_one_media_entry_across_package_parts() {
+        let bytes = vec![5, 6, 7, 8];
+        let xml = Docx::new()
+            .add_paragraph(image_paragraph("body", bytes.clone()))
+            .header(Header::new().add_paragraph(image_paragraph("header", bytes.clone())))
+            .footer(Footer::new().add_paragraph(image_paragraph("footer", bytes)))
+            .build();
+
+        assert_eq!(xml.media.len(), 1);
+        assert!(String::from_utf8_lossy(&xml.document_rels).contains("relationships/image"));
+        assert!(String::from_utf8_lossy(&xml.header_rels[0]).contains("relationships/image"));
+        assert!(String::from_utf8_lossy(&xml.footer_rels[0]).contains("relationships/image"));
+    }
+
+    #[test]
+    fn images_are_collected_from_top_level_sdt_and_section_content() {
+        let tag = StructuredDataTag::new().add_paragraph(image_paragraph("sdt", vec![9]));
+        let section = Section::new().add_paragraph(image_paragraph("section", vec![10]));
+        let xml = Docx::new()
+            .add_structured_data_tag(tag)
+            .add_section(section)
+            .build();
+
+        assert_eq!(xml.media.len(), 2);
+        assert_eq!(
+            String::from_utf8_lossy(&xml.document_rels)
+                .matches("relationships/image")
+                .count(),
+            2
+        );
+    }
+}
+
+#[cfg(test)]
+mod document_traversal_tests {
+    use super::*;
+
+    #[test]
+    fn footnotes_are_collected_from_table_paragraphs() {
+        let footnote = Footnote::new()
+            .add_content(Paragraph::new().add_run(Run::new().add_text("nested footnote")));
+        let table = Table::new(vec![TableRow::new(vec![TableCell::new().add_paragraph(
+            Paragraph::new().add_run(Run::new().add_footnote_reference(footnote)),
+        )])]);
+
+        let xml = Docx::new().add_table(table).build();
+
+        assert!(String::from_utf8_lossy(&xml.footnotes).contains("nested footnote"));
+        assert!(String::from_utf8_lossy(&xml.document_rels).contains("relationships/footnotes"));
     }
 }
 


### PR DESCRIPTION
## Summary

- collect images and footnotes through one shared document-tree visitor, including nested sections, SDTs, tables, hyperlinks, and tracked changes
- keep image relationships scoped to each document/header/footer part while deduplicating physical media package-wide
- preserve the public `Docx::collect_footnotes` behavior and document the scope decisions with English Rustdoc
- add the change to the planned 0.4.22 changelog

## Test-first evidence

The new regression tests failed before implementation for:

- duplicate media across body/header/footer (`3` entries instead of `1`)
- missing relationships in repeated header parts
- images under top-level SDT/Section nodes (`0` entries instead of `2`)
- footnotes nested in table paragraphs
- duplicate relationships for identical media inside one part

All pass after the shared visitor and media registry changes.

## Performance

`write_docx_repeated_images`, 20 Criterion samples against `origin/main` on the same machine:

- `origin/main`: 1.3066 ms median
- this branch: 1.2597 ms median
- change: -4.05% (`p = 0.00`)

Identical media referenced by the body, header, and footer is also emitted once instead of three times.

## Validation

- `CARGO_INCREMENTAL=0 cargo test --workspace -- --test-threads=1`
- `CARGO_INCREMENTAL=0 cargo test --workspace --no-default-features -- --test-threads=1`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- `cargo bench --workspace --no-run`
- `cargo fmt --all -- --check`
- `git diff --check`
