### PR TITLE
Bump emf-rs to 0.0.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,7 +284,7 @@ checksum = "9eb1aa714776b75c7e67e1da744b81a129b3ff919c8712b5e1b32252c1f07cc7"
 [[package]]
 name = "emf-core"
 version = "0.1.0"
-source = "git+https://github.com/mythrnr/emf-rs.git?tag=0.0.7#a440894ecdb35db165a9b4e8dce39f63617baadc"
+source = "git+https://github.com/mythrnr/emf-rs.git?tag=0.0.10#bacb9029f95cebe4fdf08050cf200b6842630b54"
 dependencies = [
  "embedded-io",
  "snafu",
@@ -1003,7 +1003,7 @@ dependencies = [
 [[package]]
 name = "wmf-core"
 version = "0.1.0"
-source = "git+https://github.com/mythrnr/wmf-rs.git?tag=0.0.23#1c552defac0384afb3207f92f9dacbd8a79ce9a9"
+source = "git+https://github.com/mythrnr/wmf-rs.git?tag=0.0.25#e2c8cde9525d32a725e0ff937f73bdd581702cb2"
 dependencies = [
  "base64",
  "codepage",

--- a/docx-wasm/Cargo.toml
+++ b/docx-wasm/Cargo.toml
@@ -14,9 +14,9 @@ crate-type = ["cdylib"]
 wasm-bindgen = "0.2"
 console_error_panic_hook = "0.1.7"
 docx-rs = { path = "../docx-core", features = ["wasm"] }
-emf-core = { git = "https://github.com/mythrnr/emf-rs.git", tag = "0.0.7", default-features = false, features = [
+emf-core = { git = "https://github.com/mythrnr/emf-rs.git", tag = "0.0.10", default-features = false, features = [
     "svg",
 ] }
-wmf-core = { git = "https://github.com/mythrnr/wmf-rs.git", tag = "0.0.23", default-features = false, features = [
+wmf-core = { git = "https://github.com/mythrnr/wmf-rs.git", tag = "0.0.25", default-features = false, features = [
     "svg",
 ] }


### PR DESCRIPTION
## Summary

- update `emf-core` from the `emf-rs` 0.0.7 tag to 0.0.10
- update the direct `wmf-core` dependency from 0.0.23 to 0.0.25, matching the version required by `emf-rs` 0.0.10
- refresh `Cargo.lock`

## Why

`emf-rs` 0.0.10 requires `wmf-rs` 0.0.25, so the direct dependency is aligned to avoid resolving two `wmf-core` revisions.

## Validation

- `cargo check --workspace`
- `cargo test --workspace -- --test-threads=1`
- `wasm-pack build docx-wasm --dev --target nodejs --out-dir /tmp/docx-wasm-emf-pkg`

The JavaScript/Jest suite was not run because the local Node executable has a broken ICU dynamic-library reference. The Rust workspace tests and the actual wasm-target build both pass.