### PR TITLE
Optimize media and section relationship handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
           bins: wasm-pack@0.13.1
       - run: corepack enable
       - run: pnpm install --frozen-lockfile
-      - run: pnpm wasm-pack:node && pnpm wasm-pack:dev && pnpm exec tsc -p tsconfig.node.json && pnpm test
+      - run: pnpm test:ci
       - name: screenshot
         run: pnpm screenshot
       - uses: reg-viz/reg-actions@f0cccbcab7e7ecf9b0434b719f1e842c97bcd2a7 # v3

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ target
 **/*.rs.bk
 dist
 node_modules
+docx-wasm/js/pkg/
 # pkg
 *.docx#
 *.docx

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Improve DOCX reading and writing performance by reducing XML allocations,
   avoiding repeated ZIP lookups, and deduplicating embedded images without
-  cloning their full buffers.
+  cloning their full buffers. Existing tables of contents are no longer deeply
+  cloned during package preparation.
 - Add `Docx::pack` to stream XML package parts directly into a DOCX archive.
   This avoids retaining every rendered XML part in memory and is faster than
   calling `Docx::build` followed by `XMLDocx::pack`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `Docx::pack` to stream XML package parts directly into a DOCX archive.
   This avoids retaining every rendered XML part in memory and is faster than
   calling `Docx::build` followed by `XMLDocx::pack`.
+- Use the streaming package path in `docx-wasm`, optimize release WASM with one
+  codegen unit and an explicit `wasm-opt -O`, and avoid rebuilding the same
+  WASM package repeatedly in CI.
 - Add `ReadDocxOptions::with_image_previews(false)` for callers that want to
   preserve original image data without generating decoded previews.
 - Fix paragraph ID normalization when generated IDs collide, and ensure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve DOCX reading and writing performance by reducing XML allocations,
   avoiding repeated ZIP lookups, and deduplicating embedded images without
   cloning their full buffers. Existing tables of contents are no longer deeply
-  cloned during package preparation.
+  cloned during package preparation, and automatic TOC expansion reuses the
+  document tree allocation without allocating style IDs per paragraph.
 - Add `Docx::pack` to stream XML package parts directly into a DOCX archive.
   This avoids retaining every rendered XML part in memory and is faster than
   calling `Docx::build` followed by `XMLDocx::pack`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,5 @@ members = [
 ]
 
 [profile.release]
-lto = true
+lto = "fat"
+codegen-units = 1

--- a/docx-core/benches/write_docx.rs
+++ b/docx-core/benches/write_docx.rs
@@ -130,6 +130,26 @@ fn bench_write_docx(c: &mut Criterion) {
             BatchSize::LargeInput,
         );
     });
+
+    let reused_picture = Pic::new_with_dimensions(vec![42; 64 * 1024], 1, 1);
+    let mut reused_picture_template = Docx::new();
+    for _ in 0..100 {
+        reused_picture_template = reused_picture_template
+            .add_paragraph(Paragraph::new().add_run(Run::new().add_image(reused_picture.clone())));
+    }
+    c.bench_function("write_docx_reused_picture", |b| {
+        b.iter_batched(
+            || reused_picture_template.clone(),
+            |docx| {
+                let mut cursor = Cursor::new(Vec::with_capacity(128 * 1024));
+                docx.build()
+                    .pack(&mut cursor)
+                    .expect("failed to write reused-picture docx");
+                black_box(cursor.into_inner());
+            },
+            BatchSize::LargeInput,
+        );
+    });
 }
 
 criterion_group!(docx_write_benches, bench_write_docx);

--- a/docx-core/benches/write_docx.rs
+++ b/docx-core/benches/write_docx.rs
@@ -108,6 +108,28 @@ fn bench_write_docx(c: &mut Criterion) {
             BatchSize::LargeInput,
         );
     });
+
+    let small_image = vec![42; 128];
+    let mut many_small_images_template = Docx::new();
+    for _ in 0..1_000 {
+        many_small_images_template =
+            many_small_images_template.add_paragraph(Paragraph::new().add_run(
+                Run::new().add_image(Pic::new_with_dimensions(small_image.clone(), 1, 1)),
+            ));
+    }
+    c.bench_function("write_docx_many_small_repeated_images", |b| {
+        b.iter_batched(
+            || many_small_images_template.clone(),
+            |docx| {
+                let mut cursor = Cursor::new(Vec::with_capacity(256 * 1024));
+                docx.build()
+                    .pack(&mut cursor)
+                    .expect("failed to write small-image docx");
+                black_box(cursor.into_inner());
+            },
+            BatchSize::LargeInput,
+        );
+    });
 }
 
 criterion_group!(docx_write_benches, bench_write_docx);

--- a/docx-core/benches/write_docx.rs
+++ b/docx-core/benches/write_docx.rs
@@ -84,6 +84,25 @@ fn bench_write_docx(c: &mut Criterion) {
         );
     });
 
+    let mut many_section_parts_template = Docx::new();
+    for number in 0..250 {
+        let header = Header::new().add_paragraph(
+            Paragraph::new().add_run(Run::new().add_text(format!("header-{number}"))),
+        );
+        let footer = Footer::new().add_paragraph(
+            Paragraph::new().add_run(Run::new().add_text(format!("footer-{number}"))),
+        );
+        many_section_parts_template =
+            many_section_parts_template.add_section(Section::new().header(header).footer(footer));
+    }
+    c.bench_function("write_docx_many_section_parts", |b| {
+        b.iter_batched(
+            || many_section_parts_template.clone(),
+            |docx| black_box(docx.build()),
+            BatchSize::LargeInput,
+        );
+    });
+
     let image = vec![42; 64 * 1024];
     let mut repeated_image_template = Docx::new();
     for _ in 0..100 {
@@ -125,6 +144,51 @@ fn bench_write_docx(c: &mut Criterion) {
                 docx.build()
                     .pack(&mut cursor)
                     .expect("failed to write small-image docx");
+                black_box(cursor.into_inner());
+            },
+            BatchSize::LargeInput,
+        );
+    });
+
+    let mut many_unique_images_template = Docx::new();
+    for number in 0_u64..1_000 {
+        let mut image = vec![42; 128];
+        image[..8].copy_from_slice(&number.to_le_bytes());
+        many_unique_images_template = many_unique_images_template.add_paragraph(
+            Paragraph::new().add_run(Run::new().add_image(Pic::new_with_dimensions(image, 1, 1))),
+        );
+    }
+    c.bench_function("write_docx_many_unique_images", |b| {
+        b.iter_batched(
+            || many_unique_images_template.clone(),
+            |docx| {
+                let mut cursor = Cursor::new(Vec::with_capacity(512 * 1024));
+                docx.build()
+                    .pack(&mut cursor)
+                    .expect("failed to write unique-image docx");
+                black_box(cursor.into_inner());
+            },
+            BatchSize::LargeInput,
+        );
+    });
+
+    let mut colliding_image_ids_template = Docx::new();
+    for number in 0_u64..1_000 {
+        let mut image = vec![42; 128];
+        image[..8].copy_from_slice(&number.to_le_bytes());
+        colliding_image_ids_template = colliding_image_ids_template.add_paragraph(
+            Paragraph::new()
+                .add_run(Run::new().add_image(Pic::new_with_dimensions(image, 1, 1).id("shared"))),
+        );
+    }
+    c.bench_function("write_docx_colliding_image_ids", |b| {
+        b.iter_batched(
+            || colliding_image_ids_template.clone(),
+            |docx| {
+                let mut cursor = Cursor::new(Vec::with_capacity(512 * 1024));
+                docx.build()
+                    .pack(&mut cursor)
+                    .expect("failed to write colliding-image-ID docx");
                 black_box(cursor.into_inner());
             },
             BatchSize::LargeInput,

--- a/docx-core/benches/write_docx.rs
+++ b/docx-core/benches/write_docx.rs
@@ -103,6 +103,23 @@ fn bench_write_docx(c: &mut Criterion) {
         );
     });
 
+    let mut colliding_paragraph_ids_template = Docx::new();
+    for id in 1_u32..=1_000 {
+        colliding_paragraph_ids_template = colliding_paragraph_ids_template
+            .add_paragraph(Paragraph::new().id(format!("{id:08x}")));
+    }
+    for _ in 0..1_000 {
+        colliding_paragraph_ids_template =
+            colliding_paragraph_ids_template.add_paragraph(Paragraph::new().id("duplicate"));
+    }
+    c.bench_function("write_docx_colliding_paragraph_ids", |b| {
+        b.iter_batched(
+            || colliding_paragraph_ids_template.clone(),
+            |docx| black_box(docx.build()),
+            BatchSize::LargeInput,
+        );
+    });
+
     let image = vec![42; 64 * 1024];
     let mut repeated_image_template = Docx::new();
     for _ in 0..100 {

--- a/docx-core/benches/write_docx.rs
+++ b/docx-core/benches/write_docx.rs
@@ -139,6 +139,32 @@ fn bench_write_docx(c: &mut Criterion) {
         );
     });
 
+    let mut large_auto_toc_template =
+        Docx::new().add_style(Style::new("Heading1", StyleType::Paragraph).name("Heading 1"));
+    for _ in 0..4 {
+        large_auto_toc_template = large_auto_toc_template
+            .add_table_of_contents(TableOfContents::new().heading_styles_range(1, 3).auto());
+    }
+    for index in 0..5_000 {
+        let style = if index % 100 == 0 {
+            "Heading1"
+        } else {
+            "NormalParagraphText"
+        };
+        large_auto_toc_template = large_auto_toc_template.add_paragraph(
+            Paragraph::new()
+                .style(style)
+                .add_run(Run::new().add_text(format!("paragraph {index}"))),
+        );
+    }
+    c.bench_function("write_docx_large_auto_tocs", |b| {
+        b.iter_batched(
+            || large_auto_toc_template.clone(),
+            |docx| black_box(docx.build()),
+            BatchSize::LargeInput,
+        );
+    });
+
     let image = vec![42; 64 * 1024];
     let mut repeated_image_template = Docx::new();
     for _ in 0..100 {

--- a/docx-core/benches/write_docx.rs
+++ b/docx-core/benches/write_docx.rs
@@ -120,6 +120,25 @@ fn bench_write_docx(c: &mut Criterion) {
         );
     });
 
+    let mut populated_static_toc = TableOfContents::new();
+    for index in 0..20 {
+        populated_static_toc = populated_static_toc.add_before_paragraph(
+            Paragraph::new().add_run(Run::new().add_text(format!("TOC context {index}"))),
+        );
+    }
+    let mut many_static_tocs_template = Docx::new();
+    for _ in 0..100 {
+        many_static_tocs_template =
+            many_static_tocs_template.add_table_of_contents(populated_static_toc.clone());
+    }
+    c.bench_function("write_docx_many_static_tocs", |b| {
+        b.iter_batched(
+            || many_static_tocs_template.clone(),
+            |docx| black_box(docx.build()),
+            BatchSize::LargeInput,
+        );
+    });
+
     let image = vec![42; 64 * 1024];
     let mut repeated_image_template = Docx::new();
     for _ in 0..100 {

--- a/docx-core/src/documents/document.rs
+++ b/docx-core/src/documents/document.rs
@@ -251,6 +251,62 @@ impl Document {
         self.section_property = self.section_property.page_num_type(p);
         self
     }
+
+    /// Iterates headers in relationship creation order.
+    ///
+    /// Relationship IDs are assigned to the document property first and then
+    /// to section children in insertion order. Preserving that order avoids a
+    /// sort and keeps double-digit IDs aligned with numbered package parts.
+    pub(crate) fn headers(&self) -> impl Iterator<Item = &(String, Header)> {
+        self.section_property.headers().chain(
+            self.children
+                .iter()
+                .filter_map(|child| match child {
+                    DocumentChild::Section(section) => Some(section),
+                    _ => None,
+                })
+                .flat_map(|section| section.property.headers()),
+        )
+    }
+
+    /// Iterates mutable headers in the same order as [`Self::headers`].
+    pub(crate) fn headers_mut(&mut self) -> impl Iterator<Item = &mut (String, Header)> {
+        self.section_property.headers_mut().chain(
+            self.children
+                .iter_mut()
+                .filter_map(|child| match child {
+                    DocumentChild::Section(section) => Some(section),
+                    _ => None,
+                })
+                .flat_map(|section| section.property.headers_mut()),
+        )
+    }
+
+    /// Iterates footers in relationship creation order.
+    pub(crate) fn footers(&self) -> impl Iterator<Item = &(String, Footer)> {
+        self.section_property.footers().chain(
+            self.children
+                .iter()
+                .filter_map(|child| match child {
+                    DocumentChild::Section(section) => Some(section),
+                    _ => None,
+                })
+                .flat_map(|section| section.property.footers()),
+        )
+    }
+
+    /// Iterates mutable footers in the same order as [`Self::footers`].
+    pub(crate) fn footers_mut(&mut self) -> impl Iterator<Item = &mut (String, Footer)> {
+        self.section_property.footers_mut().chain(
+            self.children
+                .iter_mut()
+                .filter_map(|child| match child {
+                    DocumentChild::Section(section) => Some(section),
+                    _ => None,
+                })
+                .flat_map(|section| section.property.footers_mut()),
+        )
+    }
 }
 
 impl BuildXML for DocumentChild {

--- a/docx-core/src/documents/elements/paragraph.rs
+++ b/docx-core/src/documents/elements/paragraph.rs
@@ -179,15 +179,17 @@ impl Paragraph {
         self
     }
 
-    pub(crate) fn wrap_by_bookmark(mut self, id: usize, name: impl Into<String>) -> Paragraph {
+    /// Wraps the existing paragraph contents in matching bookmark markers.
+    ///
+    /// Mutating in place lets automatic TOC expansion bookmark headings
+    /// without moving each paragraph out of the document tree.
+    pub(crate) fn wrap_by_bookmark(&mut self, id: usize, name: impl Into<String>) {
         self.children.insert(
             0,
             ParagraphChild::BookmarkStart(BookmarkStart::new(id, name)),
         );
         self.children
             .push(ParagraphChild::BookmarkEnd(BookmarkEnd::new(id)));
-
-        self
     }
 
     pub fn add_hyperlink(mut self, link: Hyperlink) -> Self {

--- a/docx-core/src/documents/elements/section_property.rs
+++ b/docx-core/src/documents/elements/section_property.rs
@@ -133,32 +133,52 @@ impl SectionProperty {
         self
     }
 
+    /// Returns the default, first, and even headers that are present.
     pub fn get_headers(&self) -> Vec<&(String, Header)> {
-        let mut headers = vec![];
-        if let Some(ref header) = self.header {
-            headers.push(header);
-        }
-        if let Some(ref header) = self.first_header {
-            headers.push(header);
-        }
-        if let Some(ref header) = self.even_header {
-            headers.push(header);
-        }
-        headers
+        self.headers().collect()
     }
 
+    /// Returns the default, first, and even footers that are present.
     pub fn get_footers(&self) -> Vec<&(String, Footer)> {
-        let mut footers = vec![];
-        if let Some(ref footer) = self.footer {
-            footers.push(footer);
-        }
-        if let Some(ref footer) = self.first_footer {
-            footers.push(footer);
-        }
-        if let Some(ref footer) = self.even_footer {
-            footers.push(footer);
-        }
-        footers
+        self.footers().collect()
+    }
+
+    /// Iterates headers without allocating the compatibility `Vec` returned by
+    /// [`Self::get_headers`].
+    pub(crate) fn headers(&self) -> impl Iterator<Item = &(String, Header)> {
+        [&self.header, &self.first_header, &self.even_header]
+            .into_iter()
+            .filter_map(Option::as_ref)
+    }
+
+    /// Iterates mutable headers so package metadata can be collected in place.
+    pub(crate) fn headers_mut(&mut self) -> impl Iterator<Item = &mut (String, Header)> {
+        [
+            &mut self.header,
+            &mut self.first_header,
+            &mut self.even_header,
+        ]
+        .into_iter()
+        .filter_map(Option::as_mut)
+    }
+
+    /// Iterates footers without allocating the compatibility `Vec` returned by
+    /// [`Self::get_footers`].
+    pub(crate) fn footers(&self) -> impl Iterator<Item = &(String, Footer)> {
+        [&self.footer, &self.first_footer, &self.even_footer]
+            .into_iter()
+            .filter_map(Option::as_ref)
+    }
+
+    /// Iterates mutable footers so package metadata can be collected in place.
+    pub(crate) fn footers_mut(&mut self) -> impl Iterator<Item = &mut (String, Footer)> {
+        [
+            &mut self.footer,
+            &mut self.first_footer,
+            &mut self.even_footer,
+        ]
+        .into_iter()
+        .filter_map(Option::as_mut)
     }
 
     pub fn page_num_type(mut self, h: PageNumType) -> Self {

--- a/docx-core/src/documents/image_collector.rs
+++ b/docx-core/src/documents/image_collector.rs
@@ -22,6 +22,7 @@ pub(crate) struct MediaRegistry {
     media: Vec<ImageIdAndBuf>,
     media_by_id: HashMap<String, usize>,
     by_fingerprint: HashMap<(usize, u32), Vec<usize>>,
+    next_suffix_by_id: HashMap<String, usize>,
 }
 
 impl MediaRegistry {
@@ -74,15 +75,30 @@ impl MediaRegistry {
         self.media
     }
 
-    fn unique_media_id(&self, preferred_id: &str) -> String {
+    /// Returns a free media ID without restarting collision scans at `_2`.
+    ///
+    /// Callers can reuse a preferred ID for different bytes. Remembering the
+    /// next suffix keeps a run of such collisions linear while still checking
+    /// explicitly registered suffixed IDs.
+    fn unique_media_id(&mut self, preferred_id: &str) -> String {
         if !self.media_by_id.contains_key(preferred_id) {
             return preferred_id.to_owned();
         }
 
-        (2usize..)
-            .map(|suffix| format!("{preferred_id}_{suffix}"))
-            .find(|candidate| !self.media_by_id.contains_key(candidate))
-            .expect("the media ID space should not be exhausted")
+        let (media_by_id, next_suffix_by_id) = (&self.media_by_id, &mut self.next_suffix_by_id);
+        let suffix = next_suffix_by_id
+            .entry(preferred_id.to_owned())
+            .or_insert(2);
+
+        loop {
+            let candidate = format!("{preferred_id}_{suffix}");
+            *suffix = suffix
+                .checked_add(1)
+                .expect("the media ID suffix space should not be exhausted");
+            if !media_by_id.contains_key(&candidate) {
+                return candidate;
+            }
+        }
     }
 }
 
@@ -102,7 +118,8 @@ struct PackagePartCollector<'a> {
     relationship_prefix: Option<&'a str>,
     relationships: Vec<ImageIdAndPath>,
     relationship_ids: HashSet<String>,
-    relationships_by_media: HashMap<usize, String>,
+    /// Maps media to the owning relationship entry, avoiding another owned ID.
+    relationships_by_media: HashMap<usize, usize>,
     footnotes: Vec<Footnote>,
 }
 
@@ -152,18 +169,21 @@ impl DocumentTreeVisitor for PackagePartCollector<'_> {
             std::mem::take(&mut picture.image),
         );
 
-        if let Some(relationship_id) = self.relationships_by_media.get(&media_index) {
-            picture.id.clone_from(relationship_id);
+        if let Some(relationship_index) = self.relationships_by_media.get(&media_index) {
+            picture
+                .id
+                .clone_from(&self.relationships[*relationship_index].0);
             return;
         }
 
         let relationship_id = self.unique_relationship_id(&preferred_relationship_id);
         let target = format!("media/{}.png", self.registry.media_id(media_index));
+        let relationship_index = self.relationships.len();
         self.relationship_ids.insert(relationship_id.clone());
         self.relationships_by_media
-            .insert(media_index, relationship_id.clone());
-        self.relationships.push((relationship_id.clone(), target));
-        picture.id = relationship_id;
+            .insert(media_index, relationship_index);
+        picture.id.clone_from(&relationship_id);
+        self.relationships.push((relationship_id, target));
     }
 
     fn visit_footnote_reference(&mut self, reference: &FootnoteReference) {
@@ -244,12 +264,18 @@ mod tests {
     fn registry_keeps_distinct_bytes_that_reuse_an_id() {
         let mut registry = MediaRegistry::default();
 
+        registry.register("shared_2", vec![0]);
         let first = registry.register("shared", vec![1, 2, 3]);
         let second = registry.register("shared", vec![4, 5, 6]);
+        let third = registry.register("shared", vec![7, 8, 9]);
 
         assert_ne!(first, second);
-        assert_eq!(registry.media.len(), 2);
+        assert_ne!(second, third);
+        assert_eq!(registry.media.len(), 4);
         assert_ne!(registry.media[first].0, registry.media[second].0);
+        assert_eq!(registry.media[first].0, "shared");
+        assert_eq!(registry.media[second].0, "shared_3");
+        assert_eq!(registry.media[third].0, "shared_4");
     }
 
     #[test]

--- a/docx-core/src/documents/image_collector.rs
+++ b/docx-core/src/documents/image_collector.rs
@@ -20,7 +20,7 @@ use crate::{
 #[derive(Default)]
 pub(crate) struct MediaRegistry {
     media: Vec<ImageIdAndBuf>,
-    media_ids: HashSet<String>,
+    media_by_id: HashMap<String, usize>,
     by_fingerprint: HashMap<(usize, u32), Vec<usize>>,
 }
 
@@ -30,7 +30,15 @@ impl MediaRegistry {
     /// Part collectors use the numeric index as their deduplication key. This
     /// avoids cloning and hashing a `media/<id>.png` target for every repeated
     /// picture while keeping the package-visible media ID encapsulated here.
+    /// Reused picture IDs are checked before calculating a content fingerprint;
+    /// byte equality still protects callers that reuse an ID for new content.
     fn register(&mut self, preferred_id: &str, bytes: Vec<u8>) -> usize {
+        if let Some(index) = self.media_by_id.get(preferred_id).copied() {
+            if self.media[index].1 == bytes {
+                return index;
+            }
+        }
+
         let fingerprint = (bytes.len(), crc32fast::hash(&bytes));
         if let Some(index) = self
             .by_fingerprint
@@ -48,7 +56,7 @@ impl MediaRegistry {
         let media_id = self.unique_media_id(preferred_id);
         let index = self.media.len();
         self.media.push((media_id.clone(), bytes));
-        self.media_ids.insert(media_id.clone());
+        self.media_by_id.insert(media_id, index);
         self.by_fingerprint
             .entry(fingerprint)
             .or_default()
@@ -67,13 +75,13 @@ impl MediaRegistry {
     }
 
     fn unique_media_id(&self, preferred_id: &str) -> String {
-        if !self.media_ids.contains(preferred_id) {
+        if !self.media_by_id.contains_key(preferred_id) {
             return preferred_id.to_owned();
         }
 
         (2usize..)
             .map(|suffix| format!("{preferred_id}_{suffix}"))
-            .find(|candidate| !self.media_ids.contains(candidate))
+            .find(|candidate| !self.media_by_id.contains_key(candidate))
             .expect("the media ID space should not be exhausted")
     }
 }
@@ -230,6 +238,18 @@ mod tests {
 
         assert_eq!(first, second);
         assert_eq!(registry.media.len(), 1);
+    }
+
+    #[test]
+    fn registry_keeps_distinct_bytes_that_reuse_an_id() {
+        let mut registry = MediaRegistry::default();
+
+        let first = registry.register("shared", vec![1, 2, 3]);
+        let second = registry.register("shared", vec![4, 5, 6]);
+
+        assert_ne!(first, second);
+        assert_eq!(registry.media.len(), 2);
+        assert_ne!(registry.media[first].0, registry.media[second].0);
     }
 
     #[test]

--- a/docx-core/src/documents/image_collector.rs
+++ b/docx-core/src/documents/image_collector.rs
@@ -118,6 +118,8 @@ struct PackagePartCollector<'a> {
     relationship_prefix: Option<&'a str>,
     relationships: Vec<ImageIdAndPath>,
     relationship_ids: HashSet<String>,
+    /// Continues collision scans without revisiting previously used suffixes.
+    next_relationship_suffix_by_id: HashMap<String, usize>,
     /// Maps media to the owning relationship entry, avoiding another owned ID.
     relationships_by_media: HashMap<usize, usize>,
     footnotes: Vec<Footnote>,
@@ -130,6 +132,7 @@ impl<'a> PackagePartCollector<'a> {
             relationship_prefix,
             relationships: Vec::new(),
             relationship_ids: HashSet::new(),
+            next_relationship_suffix_by_id: HashMap::new(),
             relationships_by_media: HashMap::new(),
             footnotes: Vec::new(),
         }
@@ -149,14 +152,31 @@ impl<'a> PackagePartCollector<'a> {
         }
     }
 
-    /// Returns an ID that is unique inside this part's relationship scope.
-    fn unique_relationship_id(&self, preferred_id: &str) -> String {
-        match self.relationship_ids.contains(preferred_id) {
-            false => preferred_id.to_owned(),
-            true => (2usize..)
-                .map(|suffix| format!("{preferred_id}_{suffix}"))
-                .find(|candidate| !self.relationship_ids.contains(candidate))
-                .expect("the relationship ID space should not be exhausted"),
+    /// Returns a unique part-local relationship ID in amortized linear time.
+    ///
+    /// Repeated preferred IDs use the next unchecked suffix instead of
+    /// restarting at `_2`, while explicit suffixed IDs are still skipped.
+    fn unique_relationship_id(&mut self, preferred_id: &str) -> String {
+        if !self.relationship_ids.contains(preferred_id) {
+            return preferred_id.to_owned();
+        }
+
+        let (relationship_ids, next_suffix_by_id) = (
+            &self.relationship_ids,
+            &mut self.next_relationship_suffix_by_id,
+        );
+        let suffix = next_suffix_by_id
+            .entry(preferred_id.to_owned())
+            .or_insert(2);
+
+        loop {
+            let candidate = format!("{preferred_id}_{suffix}");
+            *suffix = suffix
+                .checked_add(1)
+                .expect("the relationship ID suffix space should not be exhausted");
+            if !relationship_ids.contains(&candidate) {
+                return candidate;
+            }
         }
     }
 }
@@ -316,5 +336,31 @@ mod tests {
 
         assert_eq!(registry.media.len(), 1);
         assert_eq!(part.relationships.len(), 1);
+    }
+
+    #[test]
+    fn colliding_picture_ids_keep_relationships_unique_and_reusable() {
+        let pictures = [
+            Pic::new_with_dimensions(vec![0], 1, 1).id("shared_2"),
+            Pic::new_with_dimensions(vec![1], 1, 1).id("shared"),
+            Pic::new_with_dimensions(vec![2], 1, 1).id("shared"),
+            Pic::new_with_dimensions(vec![1], 1, 1).id("shared"),
+        ];
+        let mut document = pictures
+            .into_iter()
+            .fold(Document::new(), |document, picture| {
+                document.add_paragraph(
+                    crate::Paragraph::new().add_run(crate::Run::new().add_image(picture)),
+                )
+            });
+        let mut registry = MediaRegistry::default();
+
+        let part = collect_document_part(&mut document, &mut registry);
+
+        assert_eq!(registry.media.len(), 3);
+        assert_eq!(part.relationships.len(), 3);
+        assert_eq!(part.relationships[0].0, "shared_2");
+        assert_eq!(part.relationships[1].0, "shared");
+        assert_eq!(part.relationships[2].0, "shared_3");
     }
 }

--- a/docx-core/src/documents/image_collector.rs
+++ b/docx-core/src/documents/image_collector.rs
@@ -25,8 +25,12 @@ pub(crate) struct MediaRegistry {
 }
 
 impl MediaRegistry {
-    /// Registers physical bytes and returns the package-global media ID.
-    fn register(&mut self, preferred_id: &str, bytes: Vec<u8>) -> String {
+    /// Registers physical bytes and returns their stable registry index.
+    ///
+    /// Part collectors use the numeric index as their deduplication key. This
+    /// avoids cloning and hashing a `media/<id>.png` target for every repeated
+    /// picture while keeping the package-visible media ID encapsulated here.
+    fn register(&mut self, preferred_id: &str, bytes: Vec<u8>) -> usize {
         let fingerprint = (bytes.len(), crc32fast::hash(&bytes));
         if let Some(index) = self
             .by_fingerprint
@@ -38,7 +42,7 @@ impl MediaRegistry {
                     .find(|index| self.media[*index].1 == bytes)
             })
         {
-            return self.media[index].0.clone();
+            return index;
         }
 
         let media_id = self.unique_media_id(preferred_id);
@@ -49,7 +53,12 @@ impl MediaRegistry {
             .entry(fingerprint)
             .or_default()
             .push(index);
-        media_id
+        index
+    }
+
+    /// Returns the package-visible ID assigned to registered media.
+    fn media_id(&self, index: usize) -> &str {
+        &self.media[index].0
     }
 
     /// Consumes the registry and returns files ready for ZIP packaging.
@@ -85,7 +94,7 @@ struct PackagePartCollector<'a> {
     relationship_prefix: Option<&'a str>,
     relationships: Vec<ImageIdAndPath>,
     relationship_ids: HashSet<String>,
-    relationships_by_target: HashMap<String, String>,
+    relationships_by_media: HashMap<usize, String>,
     footnotes: Vec<Footnote>,
 }
 
@@ -96,7 +105,7 @@ impl<'a> PackagePartCollector<'a> {
             relationship_prefix,
             relationships: Vec::new(),
             relationship_ids: HashSet::new(),
-            relationships_by_target: HashMap::new(),
+            relationships_by_media: HashMap::new(),
             footnotes: Vec::new(),
         }
     }
@@ -130,21 +139,21 @@ impl<'a> PackagePartCollector<'a> {
 impl DocumentTreeVisitor for PackagePartCollector<'_> {
     fn visit_picture(&mut self, picture: &mut Pic) {
         let preferred_relationship_id = self.relationship_id(&picture.id);
-        let media_id = self.registry.register(
+        let media_index = self.registry.register(
             &preferred_relationship_id,
             std::mem::take(&mut picture.image),
         );
-        let target = format!("media/{media_id}.png");
 
-        if let Some(relationship_id) = self.relationships_by_target.get(&target) {
+        if let Some(relationship_id) = self.relationships_by_media.get(&media_index) {
             picture.id.clone_from(relationship_id);
             return;
         }
 
         let relationship_id = self.unique_relationship_id(&preferred_relationship_id);
+        let target = format!("media/{}.png", self.registry.media_id(media_index));
         self.relationship_ids.insert(relationship_id.clone());
-        self.relationships_by_target
-            .insert(target.clone(), relationship_id.clone());
+        self.relationships_by_media
+            .insert(media_index, relationship_id.clone());
         self.relationships.push((relationship_id.clone(), target));
         picture.id = relationship_id;
     }
@@ -210,6 +219,18 @@ pub(crate) fn collect_footer_part(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn registry_reuses_the_stable_index_for_identical_media() {
+        let bytes = vec![1, 2, 3, 4];
+        let mut registry = MediaRegistry::default();
+
+        let first = registry.register("first", bytes.clone());
+        let second = registry.register("second", bytes);
+
+        assert_eq!(first, second);
+        assert_eq!(registry.media.len(), 1);
+    }
 
     #[test]
     fn registry_deduplicates_identical_media_but_keeps_part_relationships() {

--- a/docx-core/src/documents/mod.rs
+++ b/docx-core/src/documents/mod.rs
@@ -2230,15 +2230,23 @@ fn ensure_unique_paragraph_id(
     used.insert(new_id);
 }
 
-/// Returns a generated paragraph ID, falling back to a deterministic scan if
-/// the generator collides with an existing value.
+/// Returns a generated paragraph ID, falling back to a deterministic scan.
+///
+/// Starting beyond the set cardinality avoids repeatedly revisiting a dense
+/// prefix of generated IDs after documents from multiple sources are merged.
+/// Lower gaps are deliberately ignored because uniqueness, not compactness, is
+/// the package invariant.
 fn next_unique_paragraph_id(used: &HashSet<String>) -> String {
     let generated = crate::generate_para_id();
     if !used.contains(&generated) {
         return generated;
     }
 
-    (1usize..)
+    let first_candidate = used
+        .len()
+        .checked_add(1)
+        .expect("the paragraph ID space should not be exhausted");
+    (first_candidate..)
         .map(|value| format!("{value:08x}"))
         .find(|candidate| !used.contains(candidate))
         .expect("the paragraph ID space should not be exhausted")
@@ -2735,6 +2743,21 @@ mod paragraph_id_tests {
         collect_para_ids_in_docx(&docx, &mut counts);
         assert!(!counts.contains_key(""));
         assert!(counts.values().all(|count| *count == 1));
+    }
+
+    #[test]
+    fn paragraph_id_fallback_skips_the_dense_used_prefix() {
+        let mut used: HashSet<String> = (1usize..=1_000)
+            .map(|value| format!("{value:08x}"))
+            .collect();
+        used.insert(crate::generate_para_id());
+
+        let first = next_unique_paragraph_id(&used);
+        assert_eq!(first, "000003ea");
+        used.insert(first);
+
+        let second = next_unique_paragraph_id(&used);
+        assert_eq!(second, "000003eb");
     }
 }
 

--- a/docx-core/src/documents/mod.rs
+++ b/docx-core/src/documents/mod.rs
@@ -794,29 +794,41 @@ impl Docx {
         crate::reset_para_id();
     }
 
-    /// Expands automatically generated tables of contents before the document
-    /// tree is normalized and inspected for dependencies.
+    /// Expands automatically generated tables of contents before dependency
+    /// collection.
+    ///
+    /// Discovery records only indexes so static tables of contents are not
+    /// cloned. Eligible tables are moved out when expanded, while `has_toc`
+    /// still reports every table of contents so preset TOC styles are added.
     fn expand_auto_tocs(&mut self) -> bool {
-        let tocs: Vec<(usize, Box<TableOfContents>)> = self
+        let mut has_toc = false;
+        let auto_toc_indexes: Vec<usize> = self
             .document
             .children
             .iter()
             .enumerate()
-            .filter_map(|(index, child)| match child {
-                DocumentChild::TableOfContents(toc) => Some((index, toc.clone())),
-                _ => None,
+            .filter_map(|(index, child)| {
+                let DocumentChild::TableOfContents(toc) = child else {
+                    return None;
+                };
+                has_toc = true;
+                (toc.items.is_empty() && toc.auto).then_some(index)
             })
             .collect();
 
-        for (index, toc) in &tocs {
-            if toc.items.is_empty() && toc.auto {
-                let children = std::mem::take(&mut self.document.children);
-                self.document.children =
-                    update_document_by_toc(children, &self.styles, *toc.clone(), *index);
-            }
+        for index in auto_toc_indexes {
+            let mut children = std::mem::take(&mut self.document.children);
+            let toc = match std::mem::replace(
+                &mut children[index],
+                DocumentChild::TableOfContents(Box::default()),
+            ) {
+                DocumentChild::TableOfContents(toc) => *toc,
+                _ => unreachable!("collected index must still contain a table of contents"),
+            };
+            self.document.children = update_document_by_toc(children, &self.styles, toc, index);
         }
 
-        !tocs.is_empty()
+        has_toc
     }
 
     /// Prepares the complete document tree for package-part rendering.
@@ -2278,9 +2290,9 @@ fn push_comment_and_comment_extended(
 }
 
 fn update_document_by_toc(
-    document_children: Vec<DocumentChild>,
+    mut document_children: Vec<DocumentChild>,
     styles: &Styles,
-    toc: TableOfContents,
+    mut toc: TableOfContents,
     toc_index: usize,
 ) -> Vec<DocumentChild> {
     let heading_map = styles.create_heading_style_map();
@@ -2295,6 +2307,7 @@ fn update_document_by_toc(
 
     if toc.instr.heading_styles_range.is_none() && !toc.instr.styles_with_levels.is_empty() {
         // INFO: if \t option set without heading styles ranges, Microsoft word does not show ToC items...
+        document_children[toc_index] = DocumentChild::TableOfContents(Box::new(toc));
         return document_children;
     }
 
@@ -2371,10 +2384,46 @@ fn update_document_by_toc(
         }
     }
 
-    let mut toc = toc;
     toc.items = items;
     children[toc_index] = DocumentChild::TableOfContents(Box::new(toc));
     children
+}
+
+#[cfg(test)]
+mod toc_expansion_tests {
+    use super::*;
+
+    fn only_toc(docx: &Docx) -> &TableOfContents {
+        let [DocumentChild::TableOfContents(toc)] = docx.document.children.as_slice() else {
+            panic!("expected exactly one table of contents");
+        };
+        toc
+    }
+
+    #[test]
+    fn static_toc_is_preserved_while_reporting_toc_presence() {
+        let toc = TableOfContents::new()
+            .alias("static")
+            .add_before_paragraph(Paragraph::new().add_run(Run::new().add_text("before")));
+        let expected = toc.clone();
+        let mut docx = Docx::new().add_table_of_contents(toc);
+
+        assert!(docx.expand_auto_tocs());
+        assert_eq!(only_toc(&docx), &expected);
+    }
+
+    #[test]
+    fn non_expandable_auto_toc_is_restored_after_being_moved() {
+        let toc = TableOfContents::new()
+            .alias("custom")
+            .add_style_with_level(StyleWithLevel::new("Custom", 1))
+            .auto();
+        let expected = toc.clone();
+        let mut docx = Docx::new().add_table_of_contents(toc);
+
+        assert!(docx.expand_auto_tocs());
+        assert_eq!(only_toc(&docx), &expected);
+    }
 }
 
 #[cfg(test)]

--- a/docx-core/src/documents/mod.rs
+++ b/docx-core/src/documents/mod.rs
@@ -179,8 +179,27 @@ pub struct Docx {
 /// Package metadata derived while normalizing a document for output.
 pub(crate) struct PackageMetadata {
     pub(crate) media: Vec<ImageIdAndBuf>,
-    pub(crate) header_rels: Vec<HeaderRels>,
-    pub(crate) footer_rels: Vec<FooterRels>,
+    /// Non-empty header relationships keyed by zero-based part index.
+    pub(crate) header_rels: Vec<(usize, HeaderRels)>,
+    /// Non-empty footer relationships keyed by zero-based part index.
+    pub(crate) footer_rels: Vec<(usize, FooterRels)>,
+}
+
+/// Expands sparse relationships only through the last part that needs them.
+///
+/// Empty buffers preserve indexes before a non-empty part; the package writer
+/// skips those sentinels instead of emitting empty relationship files.
+fn build_sparse_relationships<T: BuildXML>(relationships: Vec<(usize, T)>) -> Vec<Vec<u8>> {
+    let mut parts = Vec::new();
+    for (index, relationships) in relationships {
+        debug_assert!(
+            index >= parts.len(),
+            "sparse relationship indexes must be strictly increasing"
+        );
+        parts.resize_with(index, Vec::new);
+        parts.push(relationships.build());
+    }
+    parts
 }
 
 impl Default for Docx {
@@ -695,31 +714,20 @@ impl Docx {
             .map(|rel| rel.build())
             .collect();
 
-        let mut headers: Vec<&(String, Header)> = self.document.section_property.get_headers();
+        let headers = self
+            .document
+            .headers()
+            .map(|(_, header)| header.build())
+            .collect();
 
-        self.document.children.iter().for_each(|child| {
-            if let DocumentChild::Section(section) = child {
-                for h in section.property.get_headers() {
-                    headers.push(h);
-                }
-            }
-        });
+        let footers = self
+            .document
+            .footers()
+            .map(|(_, footer)| footer.build())
+            .collect();
 
-        headers.sort_by(|a, b| a.0.cmp(&b.0));
-        let headers = headers.iter().map(|h| h.1.build()).collect();
-
-        let mut footers: Vec<&(String, Footer)> = self.document.section_property.get_footers();
-
-        self.document.children.iter().for_each(|child| {
-            if let DocumentChild::Section(section) = child {
-                for h in section.property.get_footers() {
-                    footers.push(h);
-                }
-            }
-        });
-
-        footers.sort_by(|a, b| a.0.cmp(&b.0));
-        let footers = footers.iter().map(|h| h.1.build()).collect();
+        let header_rels = build_sparse_relationships(package.header_rels);
+        let footer_rels = build_sparse_relationships(package.footer_rels);
 
         XMLDocx {
             content_type: self.content_type.build(),
@@ -729,8 +737,8 @@ impl Docx {
             document: self.document.build(),
             comments: self.comments.build(),
             document_rels: self.document_rels.build(),
-            header_rels: package.header_rels.into_iter().map(|r| r.build()).collect(),
-            footer_rels: package.footer_rels.into_iter().map(|r| r.build()).collect(),
+            header_rels,
+            footer_rels,
             settings: self.settings.build(),
             font_table: self.font_table.build(),
             numberings: self.numberings.build(),
@@ -831,15 +839,23 @@ impl Docx {
         let footer_images = self.collect_footer_images(&mut media);
         self.document_rels.images = document_part.relationships;
 
-        let mut header_rels = vec![HeaderRels::new(); 3];
-        for (rels, images) in header_rels.iter_mut().zip(header_images) {
-            rels.set_images(images);
-        }
+        let header_rels = header_images
+            .into_iter()
+            .map(|(index, images)| {
+                let mut rels = HeaderRels::new();
+                rels.set_images(images);
+                (index, rels)
+            })
+            .collect();
 
-        let mut footer_rels = vec![FooterRels::new(); 3];
-        for (rels, images) in footer_rels.iter_mut().zip(footer_images) {
-            rels.set_images(images);
-        }
+        let footer_rels = footer_images
+            .into_iter()
+            .map(|(index, images)| {
+                let mut rels = FooterRels::new();
+                rels.set_images(images);
+                (index, rels)
+            })
+            .collect();
 
         if !document_part.footnotes.is_empty() {
             self.footnotes.add(document_part.footnotes);
@@ -1186,46 +1202,42 @@ impl Docx {
         }
     }
 
-    /// Collects image relationships for the default, first, and even headers.
+    /// Collects image relationships for every header in package order.
     ///
     /// Each entry deliberately uses a separate relationship scope while all
-    /// entries share the package-wide media registry. This preserves valid
-    /// header `.rels` files without storing duplicate image bytes.
-    fn collect_header_images(&mut self, media: &mut MediaRegistry) -> Vec<Vec<ImageIdAndPath>> {
-        let mut images = vec![Vec::new(); 3];
-        let headers = [
-            &mut self.document.section_property.header,
-            &mut self.document.section_property.first_header,
-            &mut self.document.section_property.even_header,
-        ];
-
-        for (images, header) in images.iter_mut().zip(headers) {
-            if let Some((_, header)) = header.as_mut() {
-                *images = collect_header_part(header, media).relationships;
-            }
-        }
-        images
+    /// entries share the package-wide media registry. Relationship creation
+    /// order matches the order used to render and write header parts.
+    fn collect_header_images(
+        &mut self,
+        media: &mut MediaRegistry,
+    ) -> Vec<(usize, Vec<ImageIdAndPath>)> {
+        self.document
+            .headers_mut()
+            .enumerate()
+            .filter_map(|(index, (_, header))| {
+                let relationships = collect_header_part(header, media).relationships;
+                (!relationships.is_empty()).then_some((index, relationships))
+            })
+            .collect()
     }
 
-    /// Collects image relationships for the default, first, and even footers.
+    /// Collects image relationships for every footer in package order.
     ///
-    /// The fixed order matches the package writer's footer part ordering. A
-    /// shared registry prevents repeated footer and body images from being
-    /// emitted as separate physical media files.
-    fn collect_footer_images(&mut self, media: &mut MediaRegistry) -> Vec<Vec<ImageIdAndPath>> {
-        let mut images = vec![Vec::new(); 3];
-        let footers = [
-            &mut self.document.section_property.footer,
-            &mut self.document.section_property.first_footer,
-            &mut self.document.section_property.even_footer,
-        ];
-
-        for (images, footer) in images.iter_mut().zip(footers) {
-            if let Some((_, footer)) = footer.as_mut() {
-                *images = collect_footer_part(footer, media).relationships;
-            }
-        }
-        images
+    /// Relationship creation order matches the package writer. A shared
+    /// registry prevents repeated footer and body images from being emitted as
+    /// separate physical media files.
+    fn collect_footer_images(
+        &mut self,
+        media: &mut MediaRegistry,
+    ) -> Vec<(usize, Vec<ImageIdAndPath>)> {
+        self.document
+            .footers_mut()
+            .enumerate()
+            .filter_map(|(index, (_, footer))| {
+                let relationships = collect_footer_part(footer, media).relationships;
+                (!relationships.is_empty()).then_some((index, relationships))
+            })
+            .collect()
     }
 
     /// Collects footnote references from the complete main document tree.
@@ -2457,6 +2469,10 @@ mod document_traversal_tests {
 mod section_part_tests {
     use super::*;
 
+    fn image_paragraph(picture: Pic) -> Paragraph {
+        Paragraph::new().add_run(Run::new().add_image(picture))
+    }
+
     #[test]
     fn add_section_preserves_all_header_and_footer_variants() {
         let section = Section::new()
@@ -2495,6 +2511,109 @@ mod section_part_tests {
                 "missing content type for {part_name}"
             );
         }
+    }
+
+    #[test]
+    fn section_images_create_relationships_for_every_part() {
+        let picture = Pic::new_with_dimensions(vec![1, 2, 3, 4], 1, 1);
+        let mut docx = Docx::new();
+
+        for _ in 0..4 {
+            docx = docx.add_section(
+                Section::new()
+                    .header(Header::new().add_paragraph(image_paragraph(picture.clone())))
+                    .footer(Footer::new().add_paragraph(image_paragraph(picture.clone()))),
+            );
+        }
+
+        let direct = docx.clone();
+        let xml = docx.build();
+
+        assert_eq!(xml.headers.len(), 4);
+        assert_eq!(xml.header_rels.len(), 4);
+        assert_eq!(xml.footers.len(), 4);
+        assert_eq!(xml.footer_rels.len(), 4);
+        assert!(xml
+            .header_rels
+            .iter()
+            .all(|rels| String::from_utf8_lossy(rels).contains("relationships/image")));
+        assert!(xml
+            .footer_rels
+            .iter()
+            .all(|rels| String::from_utf8_lossy(rels).contains("relationships/image")));
+        assert_eq!(xml.media.len(), 1);
+
+        let mut cursor = std::io::Cursor::new(Vec::new());
+        direct
+            .pack(&mut cursor)
+            .expect("failed to directly pack document");
+        let mut archive =
+            zip::ZipArchive::new(std::io::Cursor::new(cursor.into_inner())).expect("invalid ZIP");
+        for path in ["word/_rels/header4.xml.rels", "word/_rels/footer4.xml.rels"] {
+            let mut relationships = String::new();
+            std::io::Read::read_to_string(
+                &mut archive.by_name(path).expect("missing relationship part"),
+                &mut relationships,
+            )
+            .expect("invalid relationship XML");
+            assert!(relationships.contains("relationships/image"));
+        }
+    }
+
+    #[test]
+    fn section_parts_keep_relationship_creation_order_past_nine() {
+        let mut docx = Docx::new();
+        for number in 1..=12 {
+            docx = docx.add_section(Section::new().header(Header::new().add_paragraph(
+                Paragraph::new().add_run(Run::new().add_text(format!("header-{number}"))),
+            )));
+        }
+
+        let xml = docx.build();
+
+        assert_eq!(xml.headers.len(), 12);
+        for (index, header) in xml.headers.iter().enumerate() {
+            let expected = format!("header-{}", index + 1);
+            assert!(
+                String::from_utf8_lossy(header).contains(&expected),
+                "header part {} did not contain {expected}",
+                index + 1
+            );
+        }
+    }
+
+    #[test]
+    fn section_parts_without_images_omit_relationship_files() {
+        let xml = Docx::new()
+            .add_section(Section::new().header(Header::new()).footer(Footer::new()))
+            .build();
+
+        assert!(xml.header_rels.is_empty());
+        assert!(xml.footer_rels.is_empty());
+
+        let mut cursor = std::io::Cursor::new(Vec::new());
+        xml.pack(&mut cursor).expect("failed to pack document");
+        let mut archive =
+            zip::ZipArchive::new(std::io::Cursor::new(cursor.into_inner())).expect("invalid ZIP");
+        assert!(archive.by_name("word/_rels/header1.xml.rels").is_err());
+        assert!(archive.by_name("word/_rels/footer1.xml.rels").is_err());
+    }
+
+    #[test]
+    fn sparse_section_relationships_keep_their_part_index() {
+        let mut docx = Docx::new();
+        for _ in 0..3 {
+            docx = docx.add_section(Section::new().header(Header::new()));
+        }
+        docx = docx.add_section(Section::new().header(Header::new().add_paragraph(
+            image_paragraph(Pic::new_with_dimensions(vec![1, 2, 3, 4], 1, 1)),
+        )));
+
+        let xml = docx.build();
+
+        assert_eq!(xml.header_rels.len(), 4);
+        assert!(xml.header_rels[..3].iter().all(Vec::is_empty));
+        assert!(String::from_utf8_lossy(&xml.header_rels[3]).contains("relationships/image"));
     }
 }
 

--- a/docx-core/src/documents/mod.rs
+++ b/docx-core/src/documents/mod.rs
@@ -2289,6 +2289,11 @@ fn push_comment_and_comment_extended(
     }
 }
 
+/// Populates an automatic TOC and bookmarks matching headings in place.
+///
+/// `document_children[toc_index]` is the temporary placeholder installed by
+/// [`Docx::expand_auto_tocs`]. Reusing the input allocation preserves child
+/// order without rebuilding the entire document vector.
 fn update_document_by_toc(
     mut document_children: Vec<DocumentChild>,
     styles: &Styles,
@@ -2297,13 +2302,6 @@ fn update_document_by_toc(
 ) -> Vec<DocumentChild> {
     let heading_map = styles.create_heading_style_map();
     let mut items = vec![];
-    let mut children = vec![];
-    let style_map: std::collections::HashMap<String, usize> = toc
-        .instr
-        .styles_with_levels
-        .iter()
-        .map(|sl| sl.0.clone())
-        .collect();
 
     if toc.instr.heading_styles_range.is_none() && !toc.instr.styles_with_levels.is_empty() {
         // INFO: if \t option set without heading styles ranges, Microsoft word does not show ToC items...
@@ -2313,26 +2311,35 @@ fn update_document_by_toc(
 
     let (min, max) = toc.instr.heading_styles_range.unwrap_or((0, 9));
 
-    for child in document_children.into_iter() {
-        match child {
-            DocumentChild::Paragraph(mut paragraph) => {
-                if let Some(heading_level) = paragraph
+    {
+        let style_map: std::collections::HashMap<&str, usize> = toc
+            .instr
+            .styles_with_levels
+            .iter()
+            .map(|style| {
+                let (style_id, level) = &style.0;
+                (style_id.as_str(), *level)
+            })
+            .collect();
+
+        for child in &mut document_children {
+            if let DocumentChild::Paragraph(paragraph) = child {
+                let heading_level = paragraph
                     .property
                     .style
                     .as_ref()
-                    .map(|p| p.val.to_string())
-                    .and_then(|sid| heading_map.get(&sid))
-                {
-                    if min <= *heading_level && max >= *heading_level {
+                    .and_then(|style| heading_map.get(&style.val))
+                    .copied();
+                if let Some(heading_level) = heading_level {
+                    if min <= heading_level && max >= heading_level {
                         let toc_key = TocKey::generate();
                         items.push(
                             TableOfContentsItem::new()
                                 .text(paragraph.raw_text())
                                 .toc_key(&toc_key)
-                                .level(*heading_level),
+                                .level(heading_level),
                         );
-                        paragraph =
-                            Box::new(paragraph.wrap_by_bookmark(generate_bookmark_id(), &toc_key));
+                        paragraph.wrap_by_bookmark(generate_bookmark_id(), &toc_key);
                     }
 
                     if let Some((_min, _max)) = toc.instr.tc_field_level_range {
@@ -2341,52 +2348,31 @@ fn update_document_by_toc(
                 }
 
                 // Support \t option. Collect toc items if style id matched.
-                if let Some(level) = paragraph
+                let custom_level = paragraph
                     .property
                     .style
                     .as_ref()
-                    .and_then(|s| style_map.get(&s.val))
-                {
-                    if min <= *level && max >= *level {
+                    .and_then(|style| style_map.get(style.val.as_str()))
+                    .copied();
+                if let Some(level) = custom_level {
+                    if min <= level && max >= level {
                         let toc_key = TocKey::generate();
                         items.push(
                             TableOfContentsItem::new()
                                 .text(paragraph.raw_text())
                                 .toc_key(&toc_key)
-                                .level(*level),
+                                .level(level),
                         );
-                        paragraph =
-                            Box::new(paragraph.wrap_by_bookmark(generate_bookmark_id(), &toc_key));
+                        paragraph.wrap_by_bookmark(generate_bookmark_id(), &toc_key);
                     }
                 }
-
-                children.push(DocumentChild::Paragraph(paragraph));
-            }
-            DocumentChild::Table(ref _table) => {
-                // TODO:
-                // for row in &table.rows {
-                //     for cell in &row.cells {
-                //         for content in &cell.children {
-                //             match content {
-                //                 TableCellContent::Paragraph(paragraph) => {}
-                //                 TableCellContent::Table(_) => {
-                //                     // TODO: Support table in table
-                //                 }
-                //             }
-                //         }
-                //     }
-                // }
-                children.push(child);
-            }
-            _ => {
-                children.push(child);
             }
         }
     }
 
     toc.items = items;
-    children[toc_index] = DocumentChild::TableOfContents(Box::new(toc));
-    children
+    document_children[toc_index] = DocumentChild::TableOfContents(Box::new(toc));
+    document_children
 }
 
 #[cfg(test)]
@@ -2423,6 +2409,73 @@ mod toc_expansion_tests {
 
         assert!(docx.expand_auto_tocs());
         assert_eq!(only_toc(&docx), &expected);
+    }
+
+    #[test]
+    fn auto_toc_expansion_preserves_child_order_and_bookmarks_headings() {
+        let mut docx = Docx::new()
+            .add_style(Style::new("Heading1", crate::StyleType::Paragraph).name("Heading 1"))
+            .add_paragraph(Paragraph::new().add_run(Run::new().add_text("before")))
+            .add_table_of_contents(TableOfContents::new().heading_styles_range(1, 3).auto())
+            .add_paragraph(
+                Paragraph::new()
+                    .style("Heading1")
+                    .add_run(Run::new().add_text("Heading")),
+            )
+            .add_table(Table::new(vec![]));
+
+        assert!(docx.expand_auto_tocs());
+        assert!(matches!(
+            docx.document.children.as_slice(),
+            [
+                DocumentChild::Paragraph(_),
+                DocumentChild::TableOfContents(_),
+                DocumentChild::Paragraph(_),
+                DocumentChild::Table(_)
+            ]
+        ));
+
+        let DocumentChild::TableOfContents(toc) = &docx.document.children[1] else {
+            panic!("expected the table of contents to remain at its original index");
+        };
+        assert_eq!(toc.items.len(), 1);
+        assert_eq!(toc.items[0].text, "Heading");
+
+        let DocumentChild::Paragraph(heading) = &docx.document.children[2] else {
+            panic!("expected the heading to remain at its original index");
+        };
+        assert!(matches!(
+            heading.children.first(),
+            Some(ParagraphChild::BookmarkStart(_))
+        ));
+        assert!(matches!(
+            heading.children.last(),
+            Some(ParagraphChild::BookmarkEnd(_))
+        ));
+    }
+
+    #[test]
+    fn auto_toc_expansion_matches_custom_styles_without_owning_their_ids() {
+        let mut docx = Docx::new()
+            .add_table_of_contents(
+                TableOfContents::new()
+                    .heading_styles_range(1, 9)
+                    .add_style_with_level(StyleWithLevel::new("CustomHeading", 2))
+                    .auto(),
+            )
+            .add_paragraph(
+                Paragraph::new()
+                    .style("CustomHeading")
+                    .add_run(Run::new().add_text("Custom heading")),
+            );
+
+        assert!(docx.expand_auto_tocs());
+        let DocumentChild::TableOfContents(toc) = &docx.document.children[0] else {
+            panic!("expected an expanded table of contents");
+        };
+        assert_eq!(toc.items.len(), 1);
+        assert_eq!(toc.items[0].text, "Custom heading");
+        assert_eq!(toc.items[0].level, 2);
     }
 }
 

--- a/docx-core/src/documents/mod.rs
+++ b/docx-core/src/documents/mod.rs
@@ -360,6 +360,56 @@ impl Docx {
         self
     }
 
+    /// Attaches one header without rebuilding the surrounding section.
+    ///
+    /// Mutating the property in place preserves pending first/even headers and
+    /// footers until each receives its own relationship and content-type entry.
+    fn attach_section_header(
+        &mut self,
+        section: &mut Section,
+        header: Header,
+        attach: fn(SectionProperty, Header, &str) -> SectionProperty,
+    ) {
+        if header.has_numbering {
+            self.document_rels.has_numberings = true;
+        }
+        let count = self.document_rels.header_count + 1;
+        let relationship_id = create_header_rid(count);
+        section.property = attach(
+            std::mem::take(&mut section.property),
+            header,
+            &relationship_id,
+        );
+        self.document_rels.header_count = count;
+        self.content_type = std::mem::take(&mut self.content_type).add_header();
+    }
+
+    /// Attaches one footer while preserving every unprocessed section part.
+    fn attach_section_footer(
+        &mut self,
+        section: &mut Section,
+        footer: Footer,
+        attach: fn(SectionProperty, Footer, &str) -> SectionProperty,
+    ) {
+        if footer.has_numbering {
+            self.document_rels.has_numberings = true;
+        }
+        let count = self.document_rels.footer_count + 1;
+        let relationship_id = create_footer_rid(count);
+        section.property = attach(
+            std::mem::take(&mut section.property),
+            footer,
+            &relationship_id,
+        );
+        self.document_rels.footer_count = count;
+        self.content_type = std::mem::take(&mut self.content_type).add_footer();
+    }
+
+    /// Appends a section and registers all of its header and footer variants.
+    ///
+    /// Each pending part is attached independently so adding a default header
+    /// cannot discard first/even headers or any footer that still needs a
+    /// relationship and content-type entry.
     pub fn add_section(mut self, s: Section) -> Docx {
         if s.has_numbering {
             // If this document has numbering, set numberings.xml to document_rels.
@@ -369,169 +419,28 @@ impl Docx {
 
         let mut new_section = s;
 
-        // header
-        if let Some(header) = new_section.temp_header {
-            if header.has_numbering {
-                self.document_rels.has_numberings = true;
-            }
-            let count = self.document_rels.header_count + 1;
-            new_section = Section {
-                property: new_section
-                    .property
-                    .header(header, &create_header_rid(count)),
-                children: new_section.children,
-                has_numbering: new_section.has_numbering,
-                temp_header: None,
-                ..Default::default()
-            };
-            self.document_rels.header_count = count;
-            self.content_type = self.content_type.add_header();
+        if let Some(header) = new_section.temp_header.take() {
+            self.attach_section_header(&mut new_section, header, SectionProperty::header);
         }
 
-        if let Some(header) = new_section.temp_first_header {
-            if header.has_numbering {
-                self.document_rels.has_numberings = true;
-            }
-            let count = self.document_rels.header_count + 1;
-            new_section = Section {
-                property: new_section
-                    .property
-                    .first_header(header, &create_header_rid(count)),
-                children: new_section.children,
-                has_numbering: new_section.has_numbering,
-                temp_first_header: None,
-                ..Default::default()
-            };
-            self.document_rels.header_count = count;
-            self.content_type = self.content_type.add_header();
+        if let Some(header) = new_section.temp_first_header.take() {
+            self.attach_section_header(&mut new_section, header, SectionProperty::first_header);
         }
 
-        if let Some(header) = new_section.temp_even_header {
-            if header.has_numbering {
-                self.document_rels.has_numberings = true;
-            }
-            let count = self.document_rels.header_count + 1;
-            new_section = Section {
-                property: new_section
-                    .property
-                    .even_header(header, &create_header_rid(count)),
-                children: new_section.children,
-                has_numbering: new_section.has_numbering,
-                temp_even_header: None,
-                ..Default::default()
-            };
-            self.document_rels.header_count = count;
-            self.content_type = self.content_type.add_header();
+        if let Some(header) = new_section.temp_even_header.take() {
+            self.attach_section_header(&mut new_section, header, SectionProperty::even_header);
         }
 
-        // header
-        if let Some(header) = new_section.temp_header {
-            if header.has_numbering {
-                self.document_rels.has_numberings = true;
-            }
-            let count = self.document_rels.header_count + 1;
-            new_section = Section {
-                property: new_section
-                    .property
-                    .header(header, &create_header_rid(count)),
-                children: new_section.children,
-                has_numbering: new_section.has_numbering,
-                temp_header: None,
-                ..Default::default()
-            };
-            self.document_rels.header_count = count;
-            self.content_type = self.content_type.add_header();
+        if let Some(footer) = new_section.temp_footer.take() {
+            self.attach_section_footer(&mut new_section, footer, SectionProperty::footer);
         }
 
-        if let Some(header) = new_section.temp_first_header {
-            if header.has_numbering {
-                self.document_rels.has_numberings = true;
-            }
-            let count = self.document_rels.header_count + 1;
-            new_section = Section {
-                property: new_section
-                    .property
-                    .first_header(header, &create_header_rid(count)),
-                children: new_section.children,
-                has_numbering: new_section.has_numbering,
-                temp_first_header: None,
-                ..Default::default()
-            };
-            self.document_rels.header_count = count;
-            self.content_type = self.content_type.add_header();
+        if let Some(footer) = new_section.temp_first_footer.take() {
+            self.attach_section_footer(&mut new_section, footer, SectionProperty::first_footer);
         }
 
-        if let Some(header) = new_section.temp_even_header {
-            if header.has_numbering {
-                self.document_rels.has_numberings = true;
-            }
-            let count = self.document_rels.header_count + 1;
-            new_section = Section {
-                property: new_section
-                    .property
-                    .even_header(header, &create_header_rid(count)),
-                children: new_section.children,
-                has_numbering: new_section.has_numbering,
-                temp_even_header: None,
-                ..Default::default()
-            };
-            self.document_rels.header_count = count;
-            self.content_type = self.content_type.add_header();
-        }
-
-        // footer
-        if let Some(footer) = new_section.temp_footer {
-            if footer.has_numbering {
-                self.document_rels.has_numberings = true;
-            }
-            let count = self.document_rels.footer_count + 1;
-            new_section = Section {
-                property: new_section
-                    .property
-                    .footer(footer, &create_footer_rid(count)),
-                children: new_section.children,
-                has_numbering: new_section.has_numbering,
-                temp_footer: None,
-                ..Default::default()
-            };
-            self.document_rels.footer_count = count;
-            self.content_type = self.content_type.add_footer();
-        }
-
-        if let Some(footer) = new_section.temp_first_footer {
-            if footer.has_numbering {
-                self.document_rels.has_numberings = true;
-            }
-            let count = self.document_rels.footer_count + 1;
-            new_section = Section {
-                property: new_section
-                    .property
-                    .first_footer(footer, &create_footer_rid(count)),
-                children: new_section.children,
-                has_numbering: new_section.has_numbering,
-                temp_first_footer: None,
-                ..Default::default()
-            };
-            self.document_rels.footer_count = count;
-            self.content_type = self.content_type.add_footer();
-        }
-
-        if let Some(footer) = new_section.temp_even_footer {
-            if footer.has_numbering {
-                self.document_rels.has_numberings = true;
-            }
-            let count = self.document_rels.footer_count + 1;
-            new_section = Section {
-                property: new_section
-                    .property
-                    .even_footer(footer, &create_footer_rid(count)),
-                children: new_section.children,
-                has_numbering: new_section.has_numbering,
-                temp_even_footer: None,
-                ..Default::default()
-            };
-            self.document_rels.footer_count = count;
-            self.content_type = self.content_type.add_footer();
+        if let Some(footer) = new_section.temp_even_footer.take() {
+            self.attach_section_footer(&mut new_section, footer, SectionProperty::even_footer);
         }
 
         self.document = self.document.add_section(new_section);
@@ -2541,6 +2450,51 @@ mod document_traversal_tests {
 
         assert!(String::from_utf8_lossy(&xml.footnotes).contains("nested footnote"));
         assert!(String::from_utf8_lossy(&xml.document_rels).contains("relationships/footnotes"));
+    }
+}
+
+#[cfg(test)]
+mod section_part_tests {
+    use super::*;
+
+    #[test]
+    fn add_section_preserves_all_header_and_footer_variants() {
+        let section = Section::new()
+            .header(Header::new())
+            .first_header(Header::new())
+            .even_header(Header::new())
+            .footer(Footer::new())
+            .first_footer(Footer::new())
+            .even_footer(Footer::new());
+
+        let docx = Docx::new().add_section(section);
+
+        assert_eq!(docx.document_rels.header_count, 3);
+        assert_eq!(docx.document_rels.footer_count, 3);
+        let DocumentChild::Section(section) = &docx.document.children[0] else {
+            panic!("expected a section");
+        };
+        assert_eq!(section.property.get_headers().len(), 3);
+        assert_eq!(section.property.get_footers().len(), 3);
+
+        let xml = docx.build();
+        assert_eq!(xml.headers.len(), 3);
+        assert_eq!(xml.footers.len(), 3);
+
+        let content_types = String::from_utf8_lossy(&xml.content_type);
+        for part_name in [
+            "header1.xml",
+            "header2.xml",
+            "header3.xml",
+            "footer1.xml",
+            "footer2.xml",
+            "footer3.xml",
+        ] {
+            assert!(
+                content_types.contains(part_name),
+                "missing content type for {part_name}"
+            );
+        }
     }
 }
 

--- a/docx-core/src/zipper/mod.rs
+++ b/docx-core/src/zipper/mod.rs
@@ -5,9 +5,14 @@ use std::io::prelude::*;
 use std::io::Seek;
 use zip::write::SimpleFileOptions;
 
-/// Writes one XML part directly into the current ZIP entry.
+/// Renders one XML part into a reusable buffer and writes it to the ZIP entry.
+///
+/// Buffering one part avoids the many tiny writes that are costly in
+/// WebAssembly while still avoiding the package-wide buffering performed by
+/// [`XMLDocx`].
 fn write_xml<W, T>(
     zip: &mut zip::ZipWriter<W>,
+    buffer: &mut Vec<u8>,
     path: &str,
     options: SimpleFileOptions,
     part: &T,
@@ -16,12 +21,15 @@ where
     W: Write + Seek,
     T: BuildXML,
 {
-    zip.start_file(path, options)?;
-    let stream = XMLBuilder::new(&mut *zip)
+    buffer.clear();
+    let stream = XMLBuilder::new(&mut *buffer)
         .into_inner()
         .map_err(xml_to_zip_error)?;
     let stream = part.build_to(stream).map_err(xml_to_zip_error)?;
     stream.into_inner().map_err(xml_to_zip_error)?;
+
+    zip.start_file(path, options)?;
+    zip.write_all(buffer)?;
     Ok(())
 }
 
@@ -163,42 +171,113 @@ where
     let options = SimpleFileOptions::default()
         .compression_method(zip::CompressionMethod::Stored)
         .unix_permissions(0o755);
+    let mut xml_buffer = Vec::new();
 
-    write_xml(&mut zip, "[Content_Types].xml", options, &docx.content_type)?;
-    write_xml(&mut zip, "_rels/.rels", options, &docx.rels)?;
-    write_xml(&mut zip, "docProps/app.xml", options, &docx.doc_props.app)?;
-    write_xml(&mut zip, "docProps/core.xml", options, &docx.doc_props.core)?;
     write_xml(
         &mut zip,
+        &mut xml_buffer,
+        "[Content_Types].xml",
+        options,
+        &docx.content_type,
+    )?;
+    write_xml(
+        &mut zip,
+        &mut xml_buffer,
+        "_rels/.rels",
+        options,
+        &docx.rels,
+    )?;
+    write_xml(
+        &mut zip,
+        &mut xml_buffer,
+        "docProps/app.xml",
+        options,
+        &docx.doc_props.app,
+    )?;
+    write_xml(
+        &mut zip,
+        &mut xml_buffer,
+        "docProps/core.xml",
+        options,
+        &docx.doc_props.core,
+    )?;
+    write_xml(
+        &mut zip,
+        &mut xml_buffer,
         "docProps/custom.xml",
         options,
         &docx.doc_props.custom,
     )?;
     write_xml(
         &mut zip,
+        &mut xml_buffer,
         "word/_rels/document.xml.rels",
         options,
         &docx.document_rels,
     )?;
-    write_xml(&mut zip, "word/document.xml", options, &docx.document)?;
-    write_xml(&mut zip, "word/styles.xml", options, &docx.styles)?;
-    write_xml(&mut zip, "word/settings.xml", options, &docx.settings)?;
-    write_xml(&mut zip, "word/fontTable.xml", options, &docx.font_table)?;
-    write_xml(&mut zip, "word/comments.xml", options, &docx.comments)?;
-    write_xml(&mut zip, "word/numbering.xml", options, &docx.numberings)?;
     write_xml(
         &mut zip,
+        &mut xml_buffer,
+        "word/document.xml",
+        options,
+        &docx.document,
+    )?;
+    write_xml(
+        &mut zip,
+        &mut xml_buffer,
+        "word/styles.xml",
+        options,
+        &docx.styles,
+    )?;
+    write_xml(
+        &mut zip,
+        &mut xml_buffer,
+        "word/settings.xml",
+        options,
+        &docx.settings,
+    )?;
+    write_xml(
+        &mut zip,
+        &mut xml_buffer,
+        "word/fontTable.xml",
+        options,
+        &docx.font_table,
+    )?;
+    write_xml(
+        &mut zip,
+        &mut xml_buffer,
+        "word/comments.xml",
+        options,
+        &docx.comments,
+    )?;
+    write_xml(
+        &mut zip,
+        &mut xml_buffer,
+        "word/numbering.xml",
+        options,
+        &docx.numberings,
+    )?;
+    write_xml(
+        &mut zip,
+        &mut xml_buffer,
         "word/commentsExtended.xml",
         options,
         &docx.comments_extended,
     )?;
-    write_xml(&mut zip, "word/footnotes.xml", options, &docx.footnotes)?;
+    write_xml(
+        &mut zip,
+        &mut xml_buffer,
+        "word/footnotes.xml",
+        options,
+        &docx.footnotes,
+    )?;
 
     let mut header_rels = package.header_rels.iter().peekable();
     for (index, (_, header)) in docx.document.headers().enumerate() {
         let number = index + 1;
         write_xml(
             &mut zip,
+            &mut xml_buffer,
             &format!("word/header{number}.xml"),
             options,
             header,
@@ -212,6 +291,7 @@ where
                 .expect("peeked header relationship should exist");
             write_xml(
                 &mut zip,
+                &mut xml_buffer,
                 &format!("word/_rels/header{number}.xml.rels"),
                 options,
                 rels,
@@ -224,6 +304,7 @@ where
         let number = index + 1;
         write_xml(
             &mut zip,
+            &mut xml_buffer,
             &format!("word/footer{number}.xml"),
             options,
             footer,
@@ -237,6 +318,7 @@ where
                 .expect("peeked footer relationship should exist");
             write_xml(
                 &mut zip,
+                &mut xml_buffer,
                 &format!("word/_rels/footer{number}.xml.rels"),
                 options,
                 rels,
@@ -256,6 +338,7 @@ where
         zip.add_directory("word/webextensions/", directory_options)?;
         write_xml(
             &mut zip,
+            &mut xml_buffer,
             "word/webextensions/taskpanes.xml",
             options,
             taskpanes,
@@ -264,6 +347,7 @@ where
         zip.add_directory("word/webextensions/_rels", directory_options)?;
         write_xml(
             &mut zip,
+            &mut xml_buffer,
             "word/webextensions/_rels/taskpanes.xml.rels",
             options,
             &docx.taskpanes_rels,
@@ -272,6 +356,7 @@ where
         for (index, extension) in docx.web_extensions.iter().enumerate() {
             write_xml(
                 &mut zip,
+                &mut xml_buffer,
                 &format!("word/webextensions/webextension{}.xml", index + 1),
                 options,
                 extension,
@@ -286,18 +371,21 @@ where
         let number = index + 1;
         write_xml(
             &mut zip,
+            &mut xml_buffer,
             &format!("customXml/_rels/item{number}.xml.rels"),
             options,
             &docx.custom_item_rels[index],
         )?;
         write_xml(
             &mut zip,
+            &mut xml_buffer,
             &format!("customXml/item{number}.xml"),
             options,
             item,
         )?;
         write_xml(
             &mut zip,
+            &mut xml_buffer,
             &format!("customXml/itemProps{number}.xml"),
             options,
             &docx.custom_item_props[index],

--- a/docx-core/src/zipper/mod.rs
+++ b/docx-core/src/zipper/mod.rs
@@ -1,5 +1,5 @@
 use crate::xml_builder::XMLBuilder;
-use crate::{BuildXML, DocumentChild, Docx, Footer, Header, PackageMetadata, XMLDocx};
+use crate::{BuildXML, Docx, PackageMetadata, XMLDocx};
 
 use std::io::prelude::*;
 use std::io::Seek;
@@ -80,7 +80,7 @@ where
         zip.start_file(format!("word/header{}.xml", i + 1), options)?;
         zip.write_all(h)?;
 
-        if let Some(rels) = xml.header_rels.get(i) {
+        if let Some(rels) = xml.header_rels.get(i).filter(|rels| !rels.is_empty()) {
             zip.start_file(format!("word/_rels/header{}.xml.rels", i + 1), options)?;
             zip.write_all(rels)?;
         }
@@ -90,7 +90,7 @@ where
         zip.start_file(format!("word/footer{}.xml", i + 1), options)?;
         zip.write_all(h)?;
 
-        if let Some(rels) = xml.footer_rels.get(i) {
+        if let Some(rels) = xml.footer_rels.get(i).filter(|rels| !rels.is_empty()) {
             zip.start_file(format!("word/_rels/footer{}.xml.rels", i + 1), options)?;
             zip.write_all(rels)?;
         }
@@ -194,14 +194,8 @@ where
     )?;
     write_xml(&mut zip, "word/footnotes.xml", options, &docx.footnotes)?;
 
-    let mut headers: Vec<&(String, Header)> = docx.document.section_property.get_headers();
-    for child in &docx.document.children {
-        if let DocumentChild::Section(section) = child {
-            headers.extend(section.property.get_headers());
-        }
-    }
-    headers.sort_by(|left, right| left.0.cmp(&right.0));
-    for (index, (_, header)) in headers.into_iter().enumerate() {
+    let mut header_rels = package.header_rels.iter().peekable();
+    for (index, (_, header)) in docx.document.headers().enumerate() {
         let number = index + 1;
         write_xml(
             &mut zip,
@@ -209,7 +203,13 @@ where
             options,
             header,
         )?;
-        if let Some(rels) = package.header_rels.get(index) {
+        if header_rels
+            .peek()
+            .is_some_and(|(part_index, _)| *part_index == index)
+        {
+            let (_, rels) = header_rels
+                .next()
+                .expect("peeked header relationship should exist");
             write_xml(
                 &mut zip,
                 &format!("word/_rels/header{number}.xml.rels"),
@@ -219,14 +219,8 @@ where
         }
     }
 
-    let mut footers: Vec<&(String, Footer)> = docx.document.section_property.get_footers();
-    for child in &docx.document.children {
-        if let DocumentChild::Section(section) = child {
-            footers.extend(section.property.get_footers());
-        }
-    }
-    footers.sort_by(|left, right| left.0.cmp(&right.0));
-    for (index, (_, footer)) in footers.into_iter().enumerate() {
+    let mut footer_rels = package.footer_rels.iter().peekable();
+    for (index, (_, footer)) in docx.document.footers().enumerate() {
         let number = index + 1;
         write_xml(
             &mut zip,
@@ -234,7 +228,13 @@ where
             options,
             footer,
         )?;
-        if let Some(rels) = package.footer_rels.get(index) {
+        if footer_rels
+            .peek()
+            .is_some_and(|(part_index, _)| *part_index == index)
+        {
+            let (_, rels) = footer_rels
+                .next()
+                .expect("peeked footer relationship should exist");
             write_xml(
                 &mut zip,
                 &format!("word/_rels/footer{number}.xml.rels"),

--- a/docx-wasm/Cargo.toml
+++ b/docx-wasm/Cargo.toml
@@ -10,6 +10,12 @@ license = "MIT"
 [lib]
 crate-type = ["cdylib"]
 
+[package.metadata.wasm-pack.profile.release]
+# Keep Binaryen's stable speed/size optimization level explicit. `-O4` was
+# larger and did not produce a repeatable runtime improvement in the Node
+# package benchmark.
+wasm-opt = ["-O"]
+
 [dependencies]
 wasm-bindgen = "0.2"
 console_error_panic_hook = "0.1.7"

--- a/docx-wasm/bench/build.js
+++ b/docx-wasm/bench/build.js
@@ -1,0 +1,59 @@
+const { performance } = require("node:perf_hooks");
+const path = require("node:path");
+
+const modulePath = process.env.DOCX_WASM_MODULE
+  ? path.resolve(process.env.DOCX_WASM_MODULE)
+  : path.resolve(__dirname, "../dist/node");
+const wasmPath = process.env.DOCX_WASM_BINARY
+  ? path.resolve(process.env.DOCX_WASM_BINARY)
+  : path.join(modulePath, "pkg/docx_wasm_bg.wasm");
+const wasm = require(modulePath);
+
+const PARAGRAPH_COUNT = Number(process.env.PARAGRAPH_COUNT ?? 2_000);
+const WARMUP_ITERATIONS = Number(process.env.WARMUP_ITERATIONS ?? 3);
+const MEASURED_ITERATIONS = Number(process.env.MEASURED_ITERATIONS ?? 10);
+
+const template = new wasm.Docx();
+for (let index = 0; index < PARAGRAPH_COUNT; index += 1) {
+  template.addParagraph(
+    new wasm.Paragraph().addRun(
+      new wasm.Run().addText(
+        `paragraph ${index}: lorem ipsum dolor sit amet, consectetur adipiscing elit`
+      )
+    )
+  );
+}
+
+const samples = [];
+let outputBytes = 0;
+for (
+  let iteration = 0;
+  iteration < WARMUP_ITERATIONS + MEASURED_ITERATIONS;
+  iteration += 1
+) {
+  const start = performance.now();
+  const output = template.build();
+  const elapsed = performance.now() - start;
+  outputBytes = output.byteLength;
+  if (iteration >= WARMUP_ITERATIONS) {
+    samples.push(elapsed);
+  }
+}
+
+samples.sort((left, right) => left - right);
+const median = samples[Math.floor(samples.length / 2)];
+const mean = samples.reduce((sum, sample) => sum + sample, 0) / samples.length;
+
+console.log(
+  JSON.stringify({
+    modulePath,
+    paragraphCount: PARAGRAPH_COUNT,
+    iterations: MEASURED_ITERATIONS,
+    outputBytes,
+    wasmBytes: require("node:fs").statSync(wasmPath).size,
+    medianMilliseconds: median,
+    meanMilliseconds: mean,
+    minMilliseconds: samples[0],
+    maxMilliseconds: samples[samples.length - 1],
+  })
+);

--- a/docx-wasm/package.json
+++ b/docx-wasm/package.json
@@ -10,15 +10,18 @@
     "wasm-pack:web": "wasm-pack build --release --out-dir dist/web/pkg && rm dist/web/pkg/.gitignore",
     "wasm-pack:node": "wasm-pack build --release --out-dir dist/node/pkg --target nodejs  && rm dist/node/pkg/.gitignore",
     "wasm-pack": "run-s wasm-pack:*",
+    "bench:build": "node bench/build.js",
     "screenshot": "cd export-png && make convert-all",
     "tsc:web": "tsc -p tsconfig.web.json --sourcemap",
     "tsc:node": "tsc -p tsconfig.node.json --sourcemap",
     "tsc": "run-s tsc:*",
-    "test": "npm run build && tsc && jest",
-    "jest": "tsc && jest",
+    "test": "run-s build jest",
+    "test:ci": "run-s wasm-pack:node copy:node-pkg tsc:node jest",
+    "jest": "jest",
     "build": "run-s tsrs copy:bindings wasm-pack tsc",
     "serve": "webpack-dev-server --open --config webpack.dev.js",
     "copy": "cpy 'dist/node/pkg/package.json'  'dist/web/pkg'",
+    "copy:node-pkg": "cpy 'dist/node/pkg/*' 'js/pkg' --flat",
     "tsrs": "cd ../ && make test",
     "copy:bindings": "cpy '../docx-core/bindings' './js/json'",
     "prepublishOnly": "pnpm run build"
@@ -36,6 +39,11 @@
       "serialize-javascript": "7.0.7",
       "shell-quote@1": "1.8.4"
     }
+  },
+  "jest": {
+    "modulePathIgnorePatterns": [
+      "<rootDir>/js/pkg/"
+    ]
   },
   "devDependencies": {
     "@types/file-saver": "2.0.7",

--- a/docx-wasm/src/doc.rs
+++ b/docx-wasm/src/doc.rs
@@ -205,13 +205,15 @@ impl Docx {
         self
     }
 
+    /// Builds the DOCX archive without retaining a second set of rendered XML
+    /// buffers in WebAssembly memory.
     pub fn build(mut self, has_numberings: bool) -> Result<Vec<u8>, JsValue> {
         let buf = Vec::new();
         let mut cur = std::io::Cursor::new(buf);
         if has_numberings {
             self.0.document_rels.has_numberings = true;
         }
-        let res = self.0.build().pack(&mut cur);
+        let res = self.0.pack(&mut cur);
         if res.is_err() {
             return Err(format!("{res:?}").into());
         }
@@ -224,5 +226,29 @@ impl Docx {
 
     pub fn comments_json(&mut self) -> String {
         self.0.comments_json()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use docx_rs::{Paragraph as CoreParagraph, Run as CoreRun};
+
+    #[test]
+    fn wasm_build_matches_buffered_package_output() {
+        let core = docx_rs::Docx::new().add_paragraph(
+            CoreParagraph::new().add_run(CoreRun::new().add_text("streamed wasm package")),
+        );
+        let mut expected = std::io::Cursor::new(Vec::new());
+        core.clone()
+            .build()
+            .pack(&mut expected)
+            .expect("failed to build buffered package");
+
+        let actual = Docx(core)
+            .build(false)
+            .expect("failed to build wasm package");
+
+        assert_eq!(actual, expected.into_inner());
     }
 }


### PR DESCRIPTION
## Summary

- return stable numeric indexes from the package-wide media registry
- reuse image relationships by media index instead of allocating, hashing, and cloning target strings
- fast-path repeated picture IDs before calculating a content fingerprint while retaining byte-equality checks
- remember the next media and part-relationship suffixes so repeated ID collisions avoid `O(n²)` rescans
- start paragraph-ID fallback beyond the used-set cardinality instead of repeatedly scanning a dense low-ID prefix
- avoid deeply cloning static tables of contents during package preparation and move auto-generated TOCs only when they need expansion
- expand automatic TOCs in place, reusing the document child allocation and borrowing custom style IDs
- bookmark matched headings in place instead of moving paragraphs out of the document tree
- attach all six section header/footer variants without rebuilding and discarding pending parts
- iterate every document and section header/footer in relationship creation order without temporary per-section vectors or lexicographic sorting
- store only non-empty header/footer relationships and omit unnecessary `.rels` files
- use `Docx::pack` directly from the WASM wrapper instead of first retaining every rendered XML part
- reuse one XML-part buffer while packaging, avoiding costly tiny WASM writes without returning to package-wide buffering
- use one release codegen unit and an explicit `wasm-opt -O`
- add a configurable Node benchmark for WASM `Docx::build`
- build the Node WASM package once in CI and reuse it for TypeScript compilation and Jest
- add English Rustdoc for media, collision handling, TOC expansion, bookmark mutation, section ordering, sparse relationships, and the WASM-oriented XML buffer
- document the changes in the future 0.4.22 changelog

SIMD is intentionally not included.

## Test-first coverage

- reproduced all-header/all-footer loss before refactoring `add_section`
- reproduced the fixed three-part relationship limit with four image-bearing sections
- reproduced `Header10` sorting before `Header2`
- reproduced empty relationship files for parts without images
- reproduced paragraph fallback rescanning from ID `1` despite a dense used prefix
- verify static TOCs remain unchanged while still enabling preset TOC styles
- verify non-expandable auto TOCs are restored unchanged after moving them out of the document tree
- verify automatic TOC expansion preserves document child order and bookmarks matched headings
- verify borrowed custom TOC style IDs retain their item text and level
- verify buffered and direct pack paths keep sparse relationship indexes
- verify colliding image IDs remain unique when explicit suffixed IDs and reused media are mixed
- verify WASM `Docx::build` produces the same ZIP bytes as the buffered package path

## Performance

Criterion comparisons against baselines saved before each optimization:

- 1,000 repeated 128-byte images: 24.93 ms -> 3.75 ms, about 84.94% faster (`p = 0.00`)
- one 64 KiB `Pic` reused 100 times: 1.49 ms -> 0.656 ms, about 59.55% faster (`p = 0.00`)
- media suffix cursor for 1,000 distinct images sharing one preferred ID: 61.75 ms -> 33.92 ms, about 44.25% faster (`p = 0.00`)
- part-relationship suffix cursor on the same collision scenario: 37.05 ms -> 6.37 ms, about 83.10% faster (`p = 0.00`)
- 1,000 occupied generated paragraph IDs plus 1,000 duplicate IDs: 72.26 ms -> 1.96 ms, about 97.22% faster (`p = 0.00`)
- 100 populated static TOCs: 5.58 ms -> 3.76 ms, Criterion estimate 29.53% faster (`p = 0.00`)

The two image collision optimizations reduce that scenario from roughly 61.75 ms initially to 6.37 ms currently. The repeated-image gains were also revalidated after the section changes.

An isolated comparison for four automatic TOCs scanning 5,000 paragraphs estimated a 9.58% improvement (`p = 0.04`), but Criterion classified it within the configured noise threshold. This pass is therefore described conservatively as removing per-paragraph allocations and document-vector rebuilding rather than claiming a stable additional percentage.

For WASM, the final release binary decreased from 4,311,399 bytes to 4,122,783 bytes (188,616 bytes, 4.37%). A repeated 10,000-paragraph Node benchmark remained at runtime parity: median-of-medians was 35.07 ms before and 35.12 ms after. The reusable one-part XML buffer was retained because writing XML directly through many tiny ZIP writes regressed WASM performance.

`wasm-opt -O4` was about 0.94% larger than `-O` in the comparison build and did not show a repeatable runtime improvement, so the release profile fixes the stable choice at `-O`.

## Validation

- `cargo test --workspace`
- `cargo test --workspace --no-default-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- `cargo bench -p docx-rs --bench write_docx --no-run`
- `cargo fmt --all -- --check`
- `pnpm test:ci` (92 tests, 183 snapshots)
- configurable WASM Node benchmark, including repeated 10,000-paragraph comparisons
- `git diff --check`
