### PR TITLE
export paragraph_id in mod.rs

### DIFF
--- a/docx-core/src/documents/mod.rs
+++ b/docx-core/src/documents/mod.rs
@@ -47,7 +47,6 @@ mod xml_docx;
 pub use build_xml::BuildXML;
 pub(crate) use history_id::HistoryId;
 pub(crate) use hyperlink_id::*;
-pub(crate) use paragraph_id::*;
 pub(crate) use paragraph_property_change_id::ParagraphPropertyChangeId;
 pub(crate) use pic_id::*;
 
@@ -71,6 +70,7 @@ pub use header::*;
 pub use header_id::*;
 pub use header_rels::*;
 pub use numberings::*;
+pub use paragraph_id::*;
 pub use rels::*;
 pub use settings::*;
 pub use styles::*;


### PR DESCRIPTION
Allow users to use `reset_para_id` just like `reset_bookmark_id`.

## What does this change?

Publicly export the contents of paragraph_id module.

## What can I check for bug fixes?

Using docx in tests to compare generated docx documents, allow the user to easily reset paragraph id generation.
