### PR TITLE
refactor: improve test failure readability

### DIFF
--- a/docx-core/src/documents/comments.rs
+++ b/docx-core/src/documents/comments.rs
@@ -47,7 +47,6 @@ impl BuildXML for Comments {
 mod tests {
 
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 

--- a/docx-core/src/documents/content_types.rs
+++ b/docx-core/src/documents/content_types.rs
@@ -206,7 +206,6 @@ impl FromXML for ContentTypes {
 mod tests {
 
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
 
     #[test]

--- a/docx-core/src/documents/custom_item.rs
+++ b/docx-core/src/documents/custom_item.rs
@@ -44,8 +44,9 @@ impl BuildXML for CustomItem {
 #[cfg(test)]
 mod tests {
 
+    use crate::xml::test_utils::assert_xml_eq;
+
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
 
     #[test]
@@ -55,8 +56,8 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(
-            c.0.to_string(),
+        assert_xml_eq(
+            &c.0.to_string(),
             r#"<ds:datastoreItem ds:itemID="{06AC5857-5C65-A94A-BCEC-37356A209BC3}" xmlns:ds="http://schemas.openxmlformats.org/officeDocument/2006/customXml"><ds:schemaRefs><ds:schemaRef ds:uri="https://hoge.com"></ds:schemaRef></ds:schemaRefs></ds:datastoreItem>"#
         );
         assert_eq!(

--- a/docx-core/src/documents/doc_props/app.rs
+++ b/docx-core/src/documents/doc_props/app.rs
@@ -34,7 +34,6 @@ impl BuildXML for AppProps {
 mod tests {
 
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 

--- a/docx-core/src/documents/doc_props/core.rs
+++ b/docx-core/src/documents/doc_props/core.rs
@@ -99,9 +99,9 @@ impl BuildXML for CoreProps {
 #[cfg(test)]
 mod tests {
 
+    use crate::xml::test_utils::assert_xml_eq;
+
     use super::*;
-    #[cfg(test)]
-    use pretty_assertions::assert_eq;
     use std::str;
 
     #[test]
@@ -118,7 +118,7 @@ mod tests {
             title: None,
         });
         let b = c.build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><cp:coreProperties xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/core-properties" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dcmitype="http://purl.org/dc/dcmitype/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><dcterms:created xsi:type="dcterms:W3CDTF">1970-01-01T00:00:00Z</dcterms:created><dc:creator>unknown</dc:creator><cp:lastModifiedBy>unknown</cp:lastModifiedBy><dcterms:modified xsi:type="dcterms:W3CDTF">1970-01-01T00:00:00Z</dcterms:modified><cp:revision>1</cp:revision></cp:coreProperties>"#
         );
@@ -138,7 +138,7 @@ mod tests {
             title: Some("title".to_owned()),
         });
         let b = c.build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><cp:coreProperties xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/core-properties" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dcmitype="http://purl.org/dc/dcmitype/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><dcterms:created xsi:type="dcterms:W3CDTF">2019-01-01</dcterms:created><dc:creator>foo</dc:creator><cp:lastModifiedBy>go</cp:lastModifiedBy><dcterms:modified xsi:type="dcterms:W3CDTF">2019-01-01</dcterms:modified><cp:revision>1</cp:revision><dc:description>bar</dc:description><dc:language>en</dc:language><dc:subject>subject</dc:subject><dc:title>title</dc:title></cp:coreProperties>"#
         );

--- a/docx-core/src/documents/document.rs
+++ b/docx-core/src/documents/document.rs
@@ -348,10 +348,10 @@ impl BuildXML for Document {
 #[cfg(test)]
 mod tests {
 
+    use crate::xml::test_utils::assert_xml_eq;
+
     use super::super::Run;
     use super::*;
-    #[cfg(test)]
-    use pretty_assertions::assert_eq;
     use std::str;
 
     #[test]
@@ -359,7 +359,7 @@ mod tests {
         let b = Document::new()
             .add_paragraph(Paragraph::new().add_run(Run::new().add_text("Hello")))
             .build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:document xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w10="urn:schemas-microsoft-com:office:word" xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing" xmlns:wps="http://schemas.microsoft.com/office/word/2010/wordprocessingShape" xmlns:wpg="http://schemas.microsoft.com/office/word/2010/wordprocessingGroup" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:wp14="http://schemas.microsoft.com/office/word/2010/wordprocessingDrawing" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml" xmlns:w15="http://schemas.microsoft.com/office/word/2012/wordml" mc:Ignorable="w14 wp14"><w:body><w:p w14:paraId="12345678"><w:pPr><w:rPr /></w:pPr><w:r><w:rPr /><w:t xml:space="preserve">Hello</w:t></w:r></w:p><w:sectPr><w:pgSz w:w="11906" w:h="16838" /><w:pgMar w:top="1985" w:right="1701" w:bottom="1701" w:left="1701" w:header="851" w:footer="992" w:gutter="0" /><w:cols w:space="425" w:num="1" /></w:sectPr></w:body></w:document>"#
         );
@@ -369,7 +369,7 @@ mod tests {
     fn test_document_with_toc() {
         let toc = TableOfContents::new().heading_styles_range(1, 3);
         let b = Document::new().add_table_of_contents(toc).build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:document xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w10="urn:schemas-microsoft-com:office:word" xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing" xmlns:wps="http://schemas.microsoft.com/office/word/2010/wordprocessingShape" xmlns:wpg="http://schemas.microsoft.com/office/word/2010/wordprocessingGroup" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:wp14="http://schemas.microsoft.com/office/word/2010/wordprocessingDrawing" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml" xmlns:w15="http://schemas.microsoft.com/office/word/2012/wordml" mc:Ignorable="w14 wp14"><w:body><w:sdt><w:sdtPr><w:rPr /></w:sdtPr><w:sdtContent><w:p w14:paraId="12345678"><w:pPr><w:rPr /></w:pPr><w:r><w:rPr /><w:fldChar w:fldCharType="begin" w:dirty="true" /><w:instrText>TOC \o &quot;1-3&quot;</w:instrText><w:fldChar w:fldCharType="separate" w:dirty="false" /></w:r></w:p><w:p w14:paraId="12345678"><w:pPr><w:rPr /></w:pPr><w:r><w:rPr /><w:fldChar w:fldCharType="end" w:dirty="false" /></w:r></w:p></w:sdtContent></w:sdt><w:sectPr><w:pgSz w:w="11906" w:h="16838" /><w:pgMar w:top="1985" w:right="1701" w:bottom="1701" w:left="1701" w:header="851" w:footer="992" w:gutter="0" /><w:cols w:space="425" w:num="1" /></w:sectPr></w:body></w:document>"#
         );
@@ -381,7 +381,7 @@ mod tests {
             .columns(2)
             .add_paragraph(Paragraph::new().add_run(Run::new().add_text("Hello")))
             .build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:document xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w10="urn:schemas-microsoft-com:office:word" xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing" xmlns:wps="http://schemas.microsoft.com/office/word/2010/wordprocessingShape" xmlns:wpg="http://schemas.microsoft.com/office/word/2010/wordprocessingGroup" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:wp14="http://schemas.microsoft.com/office/word/2010/wordprocessingDrawing" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml" xmlns:w15="http://schemas.microsoft.com/office/word/2012/wordml" mc:Ignorable="w14 wp14"><w:body><w:p w14:paraId="12345678"><w:pPr><w:rPr /></w:pPr><w:r><w:rPr /><w:t xml:space="preserve">Hello</w:t></w:r></w:p><w:sectPr><w:pgSz w:w="11906" w:h="16838" /><w:pgMar w:top="1985" w:right="1701" w:bottom="1701" w:left="1701" w:header="851" w:footer="992" w:gutter="0" /><w:cols w:space="425" w:num="2" /></w:sectPr></w:body></w:document>"#
         );

--- a/docx-core/src/documents/elements/a_graphic.rs
+++ b/docx-core/src/documents/elements/a_graphic.rs
@@ -39,7 +39,6 @@ impl BuildXML for AGraphic {
 mod tests {
 
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
 
     #[test]

--- a/docx-core/src/documents/elements/abstract_numbering.rs
+++ b/docx-core/src/documents/elements/abstract_numbering.rs
@@ -62,8 +62,8 @@ impl BuildXML for AbstractNumbering {
 mod tests {
 
     use super::*;
-    #[cfg(test)]
     use crate::documents::{Level, LevelJc, LevelText, NumberFormat, Start};
+    use crate::xml::test_utils::assert_xml_eq;
     use pretty_assertions::assert_eq;
     use std::str;
 
@@ -78,7 +78,7 @@ mod tests {
             LevelJc::new("left"),
         ));
         let b = c.build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<w:abstractNum w:abstractNumId="0"><w:lvl w:ilvl="1"><w:start w:val="1" /><w:numFmt w:val="decimal" /><w:lvlText w:val="%4." /><w:lvlJc w:val="left" /><w:pPr><w:rPr /></w:pPr><w:rPr /></w:lvl></w:abstractNum>"#
         );

--- a/docx-core/src/documents/elements/based_on.rs
+++ b/docx-core/src/documents/elements/based_on.rs
@@ -40,7 +40,6 @@ impl BuildXML for BasedOn {
 mod tests {
 
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 

--- a/docx-core/src/documents/elements/bookmark_end.rs
+++ b/docx-core/src/documents/elements/bookmark_end.rs
@@ -30,7 +30,6 @@ impl BuildXML for BookmarkEnd {
 mod tests {
 
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 

--- a/docx-core/src/documents/elements/bookmark_start.rs
+++ b/docx-core/src/documents/elements/bookmark_start.rs
@@ -34,7 +34,6 @@ impl BuildXML for BookmarkStart {
 mod tests {
 
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 

--- a/docx-core/src/documents/elements/cell_margins.rs
+++ b/docx-core/src/documents/elements/cell_margins.rs
@@ -94,7 +94,6 @@ impl BuildXML for CellMargins {
 mod tests {
 
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 

--- a/docx-core/src/documents/elements/character_spacing.rs
+++ b/docx-core/src/documents/elements/character_spacing.rs
@@ -38,7 +38,6 @@ impl Serialize for CharacterSpacing {
 mod tests {
 
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 

--- a/docx-core/src/documents/elements/color.rs
+++ b/docx-core/src/documents/elements/color.rs
@@ -101,7 +101,6 @@ impl Serialize for Color {
 mod tests {
 
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 

--- a/docx-core/src/documents/elements/comment.rs
+++ b/docx-core/src/documents/elements/comment.rs
@@ -121,8 +121,9 @@ impl BuildXML for Comment {
 #[cfg(test)]
 mod tests {
 
+    use crate::xml::test_utils::assert_xml_eq;
+
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 
@@ -138,7 +139,7 @@ mod tests {
     #[test]
     fn test_comment_with_default_paragraph() {
         let b = Comment::new(1).add_paragraph(Paragraph::new()).build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<w:comment w:id="1" w:author="unnamed" w:date="1970-01-01T00:00:00Z" w:initials=""><w:p w14:paraId="12345678"><w:pPr><w:rPr /></w:pPr></w:p></w:comment>"#
         );

--- a/docx-core/src/documents/elements/comment_extended.rs
+++ b/docx-core/src/documents/elements/comment_extended.rs
@@ -47,7 +47,6 @@ impl BuildXML for CommentExtended {
 mod tests {
 
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     #[test]
     fn test_comment_extended_json() {

--- a/docx-core/src/documents/elements/comment_range_end.rs
+++ b/docx-core/src/documents/elements/comment_range_end.rs
@@ -36,16 +36,16 @@ impl BuildXML for CommentRangeEnd {
 #[cfg(test)]
 mod tests {
 
+    use crate::xml::test_utils::assert_xml_eq;
+
     use super::*;
-    #[cfg(test)]
-    use pretty_assertions::assert_eq;
     use std::str;
 
     #[test]
     fn test_comment_range_end() {
         let c = CommentRangeEnd::new(1);
         let b = c.build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<w:r><w:rPr /></w:r><w:commentRangeEnd w:id="1" /><w:r><w:commentReference w:id="1" /></w:r>"#
         );

--- a/docx-core/src/documents/elements/comment_range_start.rs
+++ b/docx-core/src/documents/elements/comment_range_start.rs
@@ -47,7 +47,6 @@ impl BuildXML for CommentRangeStart {
 mod tests {
 
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 

--- a/docx-core/src/documents/elements/data_binding.rs
+++ b/docx-core/src/documents/elements/data_binding.rs
@@ -51,7 +51,6 @@ impl BuildXML for DataBinding {
 mod tests {
 
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 

--- a/docx-core/src/documents/elements/default_tab_stop.rs
+++ b/docx-core/src/documents/elements/default_tab_stop.rs
@@ -39,7 +39,6 @@ impl Serialize for DefaultTabStop {
 mod tests {
 
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 

--- a/docx-core/src/documents/elements/delete.rs
+++ b/docx-core/src/documents/elements/delete.rs
@@ -118,15 +118,15 @@ impl BuildXML for Delete {
 #[cfg(test)]
 mod tests {
 
+    use crate::xml::test_utils::assert_xml_eq;
+
     use super::*;
-    #[cfg(test)]
-    use pretty_assertions::assert_eq;
     use std::str;
 
     #[test]
     fn test_delete_default() {
         let b = Delete::new().add_run(Run::new()).build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<w:del w:id="123" w:author="unnamed" w:date="1970-01-01T00:00:00Z"><w:r><w:rPr /></w:r></w:del>"#
         );

--- a/docx-core/src/documents/elements/delete_instr_text.rs
+++ b/docx-core/src/documents/elements/delete_instr_text.rs
@@ -77,7 +77,6 @@ impl Serialize for DeleteInstrText {
 mod tests {
 
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 

--- a/docx-core/src/documents/elements/delete_text.rs
+++ b/docx-core/src/documents/elements/delete_text.rs
@@ -43,7 +43,6 @@ impl BuildXML for DeleteText {
 mod tests {
 
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 

--- a/docx-core/src/documents/elements/doc_defaults.rs
+++ b/docx-core/src/documents/elements/doc_defaults.rs
@@ -78,16 +78,16 @@ impl BuildXML for DocDefaults {
 #[cfg(test)]
 mod tests {
 
+    use crate::xml::test_utils::assert_xml_eq;
+
     use super::*;
-    #[cfg(test)]
-    use pretty_assertions::assert_eq;
     use std::str;
 
     #[test]
     fn test_build() {
         let c = DocDefaults::new();
         let b = c.build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<w:docDefaults><w:rPrDefault><w:rPr /></w:rPrDefault><w:pPrDefault><w:pPr><w:rPr /></w:pPr></w:pPrDefault></w:docDefaults>"#
         );

--- a/docx-core/src/documents/elements/drawing.rs
+++ b/docx-core/src/documents/elements/drawing.rs
@@ -156,16 +156,16 @@ impl BuildXML for Drawing {
 #[cfg(test)]
 mod tests {
 
+    use crate::xml::test_utils::assert_xml_eq;
+
     use super::*;
-    #[cfg(test)]
-    use pretty_assertions::assert_eq;
     use std::str;
 
     #[test]
     fn test_drawing_build_with_pic() {
         let pic = Pic::new_with_dimensions(Vec::new(), 320, 240);
         let d = Drawing::new().pic(pic).build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&d).unwrap(),
             r#"<w:drawing><wp:inline distT="0" distB="0" distL="0" distR="0"><wp:extent cx="3048000" cy="2286000" /><wp:effectExtent b="0" l="0" r="0" t="0" /><wp:docPr id="1" name="Figure" /><wp:cNvGraphicFramePr><a:graphicFrameLocks xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" noChangeAspect="1" /></wp:cNvGraphicFramePr><a:graphic xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"><a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/picture"><pic:pic xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture"><pic:nvPicPr><pic:cNvPr id="0" name="" /><pic:cNvPicPr><a:picLocks noChangeAspect="1" noChangeArrowheads="1" /></pic:cNvPicPr></pic:nvPicPr><pic:blipFill><a:blip r:embed="rIdImage123" /><a:srcRect /><a:stretch><a:fillRect /></a:stretch></pic:blipFill><pic:spPr bwMode="auto"><a:xfrm rot="0"><a:off x="0" y="0" /><a:ext cx="3048000" cy="2286000" /></a:xfrm><a:prstGeom prst="rect"><a:avLst /></a:prstGeom></pic:spPr></pic:pic></a:graphicData></a:graphic></wp:inline></w:drawing>"#
         );
@@ -175,7 +175,7 @@ mod tests {
     fn test_drawing_build_with_pic_overlap() {
         let pic = Pic::new_with_dimensions(Vec::new(), 320, 240).overlapping();
         let d = Drawing::new().pic(pic).build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&d).unwrap(),
             r#"<w:drawing><wp:inline distT="0" distB="0" distL="0" distR="0"><wp:extent cx="3048000" cy="2286000" /><wp:effectExtent b="0" l="0" r="0" t="0" /><wp:wrapNone /><wp:docPr id="1" name="Figure" /><wp:cNvGraphicFramePr><a:graphicFrameLocks xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" noChangeAspect="1" /></wp:cNvGraphicFramePr><a:graphic xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"><a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/picture"><pic:pic xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture"><pic:nvPicPr><pic:cNvPr id="0" name="" /><pic:cNvPicPr><a:picLocks noChangeAspect="1" noChangeArrowheads="1" /></pic:cNvPicPr></pic:nvPicPr><pic:blipFill><a:blip r:embed="rIdImage123" /><a:srcRect /><a:stretch><a:fillRect /></a:stretch></pic:blipFill><pic:spPr bwMode="auto"><a:xfrm rot="0"><a:off x="0" y="0" /><a:ext cx="3048000" cy="2286000" /></a:xfrm><a:prstGeom prst="rect"><a:avLst /></a:prstGeom></pic:spPr></pic:pic></a:graphicData></a:graphic></wp:inline></w:drawing>"#
         );
@@ -188,7 +188,7 @@ mod tests {
         pic = pic.relative_from_v(RelativeFromVType::Paragraph);
         pic = pic.position_h(DrawingPosition::Align(PicAlign::Right));
         let d = Drawing::new().pic(pic).build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&d).unwrap(),
             r#"<w:drawing><wp:anchor distT="0" distB="0" distL="0" distR="0" simplePos="0" allowOverlap="0" behindDoc="0" locked="0" layoutInCell="0" relativeHeight="190500"><wp:simplePos x="0" y="0" /><wp:positionH relativeFrom="column"><wp:align>right</wp:align></wp:positionH><wp:positionV relativeFrom="paragraph"><wp:posOffset>0</wp:posOffset></wp:positionV><wp:extent cx="3048000" cy="2286000" /><wp:effectExtent b="0" l="0" r="0" t="0" /><wp:wrapSquare wrapText="bothSides" /><wp:docPr id="1" name="Figure" /><wp:cNvGraphicFramePr><a:graphicFrameLocks xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" noChangeAspect="1" /></wp:cNvGraphicFramePr><a:graphic xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"><a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/picture"><pic:pic xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture"><pic:nvPicPr><pic:cNvPr id="0" name="" /><pic:cNvPicPr><a:picLocks noChangeAspect="1" noChangeArrowheads="1" /></pic:cNvPicPr></pic:nvPicPr><pic:blipFill><a:blip r:embed="rIdImage123" /><a:srcRect /><a:stretch><a:fillRect /></a:stretch></pic:blipFill><pic:spPr bwMode="auto"><a:xfrm rot="0"><a:off x="0" y="0" /><a:ext cx="3048000" cy="2286000" /></a:xfrm><a:prstGeom prst="rect"><a:avLst /></a:prstGeom></pic:spPr></pic:pic></a:graphicData></a:graphic></wp:anchor></w:drawing>"#
         );
@@ -203,7 +203,7 @@ mod tests {
             .offset_y(400 * 9525);
 
         let d = Drawing::new().pic(pic).build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&d).unwrap(),
             r#"<w:drawing><wp:anchor distT="0" distB="0" distL="0" distR="0" simplePos="0" allowOverlap="0" behindDoc="0" locked="0" layoutInCell="0" relativeHeight="190500"><wp:simplePos x="0" y="0" /><wp:positionH relativeFrom="margin"><wp:posOffset>2857500</wp:posOffset></wp:positionH><wp:positionV relativeFrom="margin"><wp:posOffset>3810000</wp:posOffset></wp:positionV><wp:extent cx="3048000" cy="2286000" /><wp:effectExtent b="0" l="0" r="0" t="0" /><wp:wrapSquare wrapText="bothSides" /><wp:docPr id="1" name="Figure" /><wp:cNvGraphicFramePr><a:graphicFrameLocks xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" noChangeAspect="1" /></wp:cNvGraphicFramePr><a:graphic xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"><a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/picture"><pic:pic xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture"><pic:nvPicPr><pic:cNvPr id="0" name="" /><pic:cNvPicPr><a:picLocks noChangeAspect="1" noChangeArrowheads="1" /></pic:cNvPicPr></pic:nvPicPr><pic:blipFill><a:blip r:embed="rIdImage123" /><a:srcRect /><a:stretch><a:fillRect /></a:stretch></pic:blipFill><pic:spPr bwMode="auto"><a:xfrm rot="0"><a:off x="0" y="0" /><a:ext cx="3048000" cy="2286000" /></a:xfrm><a:prstGeom prst="rect"><a:avLst /></a:prstGeom></pic:spPr></pic:pic></a:graphicData></a:graphic></wp:anchor></w:drawing>"#
         );

--- a/docx-core/src/documents/elements/fit_text.rs
+++ b/docx-core/src/documents/elements/fit_text.rs
@@ -37,7 +37,6 @@ impl BuildXML for FitText {
 mod tests {
 
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 

--- a/docx-core/src/documents/elements/fld_char.rs
+++ b/docx-core/src/documents/elements/fld_char.rs
@@ -46,7 +46,6 @@ impl BuildXML for FieldChar {
 mod tests {
 
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 

--- a/docx-core/src/documents/elements/font.rs
+++ b/docx-core/src/documents/elements/font.rs
@@ -40,16 +40,16 @@ impl<'a> BuildXML for Font<'a> {
 #[cfg(test)]
 mod tests {
 
+    use crate::xml::test_utils::assert_xml_eq;
+
     use super::*;
-    #[cfg(test)]
-    use pretty_assertions::assert_eq;
     use std::str;
 
     #[test]
     fn test_build() {
         let c = Font::new("Arial", "00", "swiss", FontPitchType::Variable);
         let b = c.build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<w:font w:name="Arial"><w:charset w:val="00" /><w:family w:val="swiss" /><w:pitch w:val="variable" /></w:font>"#
         );

--- a/docx-core/src/documents/elements/footnote.rs
+++ b/docx-core/src/documents/elements/footnote.rs
@@ -70,15 +70,15 @@ impl BuildXML for Footnote {
 #[cfg(test)]
 mod tests {
 
+    use crate::xml::test_utils::assert_xml_eq;
+
     use super::*;
-    #[cfg(test)]
-    use pretty_assertions::assert_eq;
     use std::str;
 
     #[test]
     fn test_footnote_build_default() {
         let b = Footnote::new().build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<w:footnote w:id="1"><w:p w14:paraId="12345678"><w:pPr><w:rPr /></w:pPr></w:p></w:footnote>"#
         );
@@ -89,7 +89,7 @@ mod tests {
         let b = Footnote::new()
             .add_content(Paragraph::new().add_run(Run::new().add_text("hello")))
             .build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<w:footnote w:id="1"><w:p w14:paraId="12345678"><w:pPr><w:rPr /></w:pPr><w:r><w:rPr /><w:t xml:space="preserve">hello</w:t></w:r></w:p></w:footnote>"#
         );

--- a/docx-core/src/documents/elements/footnote_reference.rs
+++ b/docx-core/src/documents/elements/footnote_reference.rs
@@ -61,7 +61,6 @@ impl Serialize for FootnoteReference {
 mod tests {
 
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 

--- a/docx-core/src/documents/elements/frame_property.rs
+++ b/docx-core/src/documents/elements/frame_property.rs
@@ -133,7 +133,6 @@ impl BuildXML for FrameProperty {
 mod tests {
 
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 

--- a/docx-core/src/documents/elements/grid_span.rs
+++ b/docx-core/src/documents/elements/grid_span.rs
@@ -37,7 +37,6 @@ impl Serialize for GridSpan {
 mod tests {
 
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 

--- a/docx-core/src/documents/elements/highlight.rs
+++ b/docx-core/src/documents/elements/highlight.rs
@@ -37,7 +37,6 @@ impl Serialize for Highlight {
 mod tests {
 
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 

--- a/docx-core/src/documents/elements/hyperlink.rs
+++ b/docx-core/src/documents/elements/hyperlink.rs
@@ -125,16 +125,16 @@ impl BuildXML for Hyperlink {
 #[cfg(test)]
 mod tests {
 
+    use crate::xml::test_utils::assert_xml_eq;
+
     use super::*;
-    #[cfg(test)]
-    use pretty_assertions::assert_eq;
     use std::str;
 
     #[test]
     fn test_hyperlink() {
         let l = Hyperlink::new("ToC1", HyperlinkType::Anchor).add_run(Run::new().add_text("hello"));
         let b = l.build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<w:hyperlink w:anchor="ToC1" w:history="1"><w:r><w:rPr /><w:t xml:space="preserve">hello</w:t></w:r></w:hyperlink>"#
         );

--- a/docx-core/src/documents/elements/indent.rs
+++ b/docx-core/src/documents/elements/indent.rs
@@ -87,7 +87,6 @@ impl Serialize for Indent {
 mod tests {
 
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 

--- a/docx-core/src/documents/elements/indent_level.rs
+++ b/docx-core/src/documents/elements/indent_level.rs
@@ -28,7 +28,6 @@ impl BuildXML for IndentLevel {
 mod tests {
 
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 

--- a/docx-core/src/documents/elements/insert.rs
+++ b/docx-core/src/documents/elements/insert.rs
@@ -160,15 +160,15 @@ impl BuildXML for Insert {
 #[cfg(test)]
 mod tests {
 
+    use crate::xml::test_utils::assert_xml_eq;
+
     use super::*;
-    #[cfg(test)]
-    use pretty_assertions::assert_eq;
     use std::str;
 
     #[test]
     fn test_ins_default() {
         let b = Insert::new(Run::new()).build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<w:ins w:id="123" w:author="unnamed" w:date="1970-01-01T00:00:00Z"><w:r><w:rPr /></w:r></w:ins>"#
         );

--- a/docx-core/src/documents/elements/instr_pageref.rs
+++ b/docx-core/src/documents/elements/instr_pageref.rs
@@ -71,7 +71,6 @@ impl std::str::FromStr for InstrPAGEREF {
 mod tests {
 
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 

--- a/docx-core/src/documents/elements/instr_text.rs
+++ b/docx-core/src/documents/elements/instr_text.rs
@@ -94,7 +94,6 @@ impl Serialize for InstrText {
 mod tests {
 
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 

--- a/docx-core/src/documents/elements/instr_toc.rs
+++ b/docx-core/src/documents/elements/instr_toc.rs
@@ -399,7 +399,6 @@ impl std::str::FromStr for InstrToC {
 mod tests {
 
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 

--- a/docx-core/src/documents/elements/justification.rs
+++ b/docx-core/src/documents/elements/justification.rs
@@ -47,7 +47,6 @@ impl Serialize for Justification {
 mod tests {
 
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 

--- a/docx-core/src/documents/elements/level.rs
+++ b/docx-core/src/documents/elements/level.rs
@@ -182,9 +182,9 @@ impl BuildXML for Level {
 #[cfg(test)]
 mod tests {
 
+    use crate::xml::test_utils::assert_xml_eq;
+
     use super::*;
-    #[cfg(test)]
-    use pretty_assertions::assert_eq;
     use std::str;
 
     #[test]
@@ -197,7 +197,7 @@ mod tests {
             LevelJc::new("left"),
         )
         .build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<w:lvl w:ilvl="1"><w:start w:val="1" /><w:numFmt w:val="decimal" /><w:lvlText w:val="%4." /><w:lvlJc w:val="left" /><w:pPr><w:rPr /></w:pPr><w:rPr /></w:lvl>"#
         );
@@ -214,7 +214,7 @@ mod tests {
         )
         .indent(Some(320), Some(SpecialIndentType::Hanging(200)), None, None)
         .build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<w:lvl w:ilvl="1"><w:start w:val="1" /><w:numFmt w:val="decimal" /><w:lvlText w:val="%4." /><w:lvlJc w:val="left" /><w:pPr><w:rPr /><w:ind w:left="320" w:right="0" w:hanging="200" /></w:pPr><w:rPr /></w:lvl>"#
         );
@@ -230,7 +230,7 @@ mod tests {
         )
         .suffix(LevelSuffixType::Space)
         .build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<w:lvl w:ilvl="1"><w:start w:val="1" /><w:numFmt w:val="decimal" /><w:lvlText w:val="%4." /><w:lvlJc w:val="left" /><w:pPr><w:rPr /></w:pPr><w:rPr /><w:suff w:val="space" /></w:lvl>"#
         );
@@ -246,7 +246,7 @@ mod tests {
         )
         .paragraph_style("a-style")
         .build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<w:lvl w:ilvl="1"><w:start w:val="1" /><w:numFmt w:val="decimal" /><w:lvlText w:val="%4." /><w:lvlJc w:val="left" /><w:pPr><w:rPr /></w:pPr><w:rPr /><w:pStyle w:val="a-style" /></w:lvl>"#
         );

--- a/docx-core/src/documents/elements/level_jc.rs
+++ b/docx-core/src/documents/elements/level_jc.rs
@@ -39,7 +39,6 @@ impl Serialize for LevelJc {
 mod tests {
 
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 

--- a/docx-core/src/documents/elements/level_override.rs
+++ b/docx-core/src/documents/elements/level_override.rs
@@ -57,16 +57,16 @@ impl BuildXML for LevelOverride {
 #[cfg(test)]
 mod tests {
 
+    use crate::xml::test_utils::assert_xml_eq;
+
     use super::*;
-    #[cfg(test)]
-    use pretty_assertions::assert_eq;
     use std::str;
 
     #[test]
     fn test_level_override() {
         let c = LevelOverride::new(1).start(2);
         let b = c.build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<w:lvlOverride w:ilvl="1"><w:startOverride w:val="2" /></w:lvlOverride>"#
         );
@@ -83,7 +83,7 @@ mod tests {
         );
         let c = LevelOverride::new(1).level(lvl);
         let b = c.build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<w:lvlOverride w:ilvl="1"><w:lvl w:ilvl="1"><w:start w:val="1" /><w:numFmt w:val="decimal" /><w:lvlText w:val="%4." /><w:lvlJc w:val="left" /><w:pPr><w:rPr /></w:pPr><w:rPr /></w:lvl></w:lvlOverride>"#
         );

--- a/docx-core/src/documents/elements/level_text.rs
+++ b/docx-core/src/documents/elements/level_text.rs
@@ -37,7 +37,6 @@ impl Serialize for LevelText {
 mod tests {
 
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 

--- a/docx-core/src/documents/elements/line_spacing.rs
+++ b/docx-core/src/documents/elements/line_spacing.rs
@@ -80,7 +80,6 @@ impl BuildXML for LineSpacing {
 mod tests {
 
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 

--- a/docx-core/src/documents/elements/move_from.rs
+++ b/docx-core/src/documents/elements/move_from.rs
@@ -117,15 +117,15 @@ impl BuildXML for MoveFrom {
 #[cfg(test)]
 mod tests {
 
+    use crate::xml::test_utils::assert_xml_eq;
+
     use super::*;
-    #[cfg(test)]
-    use pretty_assertions::assert_eq;
     use std::str;
 
     #[test]
     fn test_move_from_default() {
         let b = MoveFrom::new().add_run(Run::new()).build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<w:moveFrom w:id="123" w:author="unnamed" w:date="1970-01-01T00:00:00Z"><w:r><w:rPr /></w:r></w:moveFrom>"#
         );

--- a/docx-core/src/documents/elements/move_to.rs
+++ b/docx-core/src/documents/elements/move_to.rs
@@ -153,15 +153,15 @@ impl BuildXML for MoveTo {
 #[cfg(test)]
 mod tests {
 
+    use crate::xml::test_utils::assert_xml_eq;
+
     use super::*;
-    #[cfg(test)]
-    use pretty_assertions::assert_eq;
     use std::str;
 
     #[test]
     fn test_move_to_default() {
         let b = MoveTo::new(Run::new()).build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<w:moveTo w:id="123" w:author="unnamed" w:date="1970-01-01T00:00:00Z"><w:r><w:rPr /></w:r></w:moveTo>"#
         );

--- a/docx-core/src/documents/elements/name.rs
+++ b/docx-core/src/documents/elements/name.rs
@@ -54,7 +54,6 @@ impl Serialize for Name {
 mod tests {
 
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 

--- a/docx-core/src/documents/elements/next.rs
+++ b/docx-core/src/documents/elements/next.rs
@@ -37,7 +37,6 @@ impl BuildXML for Next {
 mod tests {
 
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 

--- a/docx-core/src/documents/elements/num_pages.rs
+++ b/docx-core/src/documents/elements/num_pages.rs
@@ -41,15 +41,15 @@ impl BuildXML for NumPages {
 #[cfg(test)]
 mod tests {
 
+    use crate::xml::test_utils::assert_xml_eq;
+
     use super::*;
-    #[cfg(test)]
-    use pretty_assertions::assert_eq;
     use std::str;
 
     #[test]
     fn test_num_pages() {
         let b = NumPages::new().build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<w:r><w:rPr /><w:fldChar w:fldCharType="begin" w:dirty="false" /><w:instrText>NUMPAGES</w:instrText><w:fldChar w:fldCharType="separate" w:dirty="false" /><w:t xml:space="preserve">1</w:t><w:fldChar w:fldCharType="end" w:dirty="false" /></w:r>"#
         );

--- a/docx-core/src/documents/elements/number_format.rs
+++ b/docx-core/src/documents/elements/number_format.rs
@@ -39,7 +39,6 @@ impl Serialize for NumberFormat {
 mod tests {
 
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 

--- a/docx-core/src/documents/elements/numbering.rs
+++ b/docx-core/src/documents/elements/numbering.rs
@@ -52,8 +52,9 @@ impl BuildXML for Numbering {
 #[cfg(test)]
 mod tests {
 
+    use crate::xml::test_utils::assert_xml_eq;
+
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 
@@ -61,7 +62,7 @@ mod tests {
     fn test_numbering() {
         let c = Numbering::new(0, 2);
         let b = c.build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<w:num w:numId="0"><w:abstractNumId w:val="2" /></w:num>"#
         );
@@ -74,7 +75,7 @@ mod tests {
             LevelOverride::new(1).start(1),
         ];
         let b = c.overrides(overrides).build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<w:num w:numId="0"><w:abstractNumId w:val="2" /><w:lvlOverride w:ilvl="0"><w:startOverride w:val="1" /></w:lvlOverride><w:lvlOverride w:ilvl="1"><w:startOverride w:val="1" /></w:lvlOverride></w:num>"#
         );

--- a/docx-core/src/documents/elements/numbering_id.rs
+++ b/docx-core/src/documents/elements/numbering_id.rs
@@ -28,7 +28,6 @@ impl BuildXML for NumberingId {
 mod tests {
 
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 

--- a/docx-core/src/documents/elements/numbering_property.rs
+++ b/docx-core/src/documents/elements/numbering_property.rs
@@ -72,8 +72,9 @@ impl Serialize for NumberingProperty {
 #[cfg(test)]
 mod tests {
 
+    use crate::xml::test_utils::assert_xml_eq;
+
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 
@@ -81,7 +82,7 @@ mod tests {
     fn test_num_property() {
         let c = NumberingProperty::new().add_num(NumberingId::new(0), IndentLevel::new(3));
         let b = c.build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<w:numPr><w:numId w:val="0" /><w:ilvl w:val="3" /></w:numPr>"#
         );

--- a/docx-core/src/documents/elements/page_margin.rs
+++ b/docx-core/src/documents/elements/page_margin.rs
@@ -76,7 +76,6 @@ impl BuildXML for PageMargin {
 mod tests {
 
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 

--- a/docx-core/src/documents/elements/page_num.rs
+++ b/docx-core/src/documents/elements/page_num.rs
@@ -41,15 +41,15 @@ impl BuildXML for PageNum {
 #[cfg(test)]
 mod tests {
 
+    use crate::xml::test_utils::assert_xml_eq;
+
     use super::*;
-    #[cfg(test)]
-    use pretty_assertions::assert_eq;
     use std::str;
 
     #[test]
     fn test_page() {
         let b = PageNum::new().build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<w:r><w:rPr /><w:fldChar w:fldCharType="begin" w:dirty="false" /><w:instrText>PAGE</w:instrText><w:fldChar w:fldCharType="separate" w:dirty="false" /><w:t xml:space="preserve">1</w:t><w:fldChar w:fldCharType="end" w:dirty="false" /></w:r>"#
         );

--- a/docx-core/src/documents/elements/page_size.rs
+++ b/docx-core/src/documents/elements/page_size.rs
@@ -75,7 +75,6 @@ impl BuildXML for PageSize {
 mod tests {
 
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 

--- a/docx-core/src/documents/elements/paragraph.rs
+++ b/docx-core/src/documents/elements/paragraph.rs
@@ -592,8 +592,9 @@ impl BuildXML for Paragraph {
 #[cfg(test)]
 mod tests {
 
+    use crate::xml::test_utils::assert_xml_eq;
+
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 
@@ -602,7 +603,7 @@ mod tests {
         let b = Paragraph::new()
             .add_run(Run::new().add_text("Hello"))
             .build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<w:p w14:paraId="12345678"><w:pPr><w:rPr /></w:pPr><w:r><w:rPr /><w:t xml:space="preserve">Hello</w:t></w:r></w:p>"#
         );
@@ -615,7 +616,7 @@ mod tests {
             .add_run(Run::new().add_text("Hello"))
             .add_bookmark_end(0)
             .build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<w:p w14:paraId="12345678"><w:pPr><w:rPr /></w:pPr><w:bookmarkStart w:id="0" w:name="article" /><w:r><w:rPr /><w:t xml:space="preserve">Hello</w:t></w:r><w:bookmarkEnd w:id="0" /></w:p>"#
         );
@@ -628,7 +629,7 @@ mod tests {
             .add_run(Run::new().add_text("Hello"))
             .add_comment_end(1)
             .build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<w:p w14:paraId="12345678"><w:pPr><w:rPr /></w:pPr><w:commentRangeStart w:id="1" /><w:r><w:rPr /><w:t xml:space="preserve">Hello</w:t></w:r><w:r><w:rPr /></w:r><w:commentRangeEnd w:id="1" /><w:r><w:commentReference w:id="1" /></w:r></w:p>"#
         );
@@ -640,7 +641,7 @@ mod tests {
             .add_run(Run::new().add_text("Hello"))
             .numbering(NumberingId::new(0), IndentLevel::new(1))
             .build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<w:p w14:paraId="12345678"><w:pPr><w:rPr /><w:numPr><w:numId w:val="0" /><w:ilvl w:val="1" /></w:numPr></w:pPr><w:r><w:rPr /><w:t xml:space="preserve">Hello</w:t></w:r></w:p>"#
         );
@@ -657,7 +658,7 @@ mod tests {
             .line_spacing(spacing)
             .add_run(Run::new().add_text("Hello"))
             .build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<w:p w14:paraId="12345678"><w:pPr><w:rPr /><w:spacing w:before="20" w:after="30" w:line="200" w:lineRule="auto" /></w:pPr><w:r><w:rPr /><w:t xml:space="preserve">Hello</w:t></w:r></w:p>"#
         );

--- a/docx-core/src/documents/elements/paragraph_property.rs
+++ b/docx-core/src/documents/elements/paragraph_property.rs
@@ -263,7 +263,7 @@ mod tests {
     use super::*;
     use crate::types::LineSpacingType;
     use crate::types::SectionType;
-    #[cfg(test)]
+    use crate::xml::test_utils::assert_xml_eq;
     use pretty_assertions::assert_eq;
     use std::str;
 
@@ -271,7 +271,7 @@ mod tests {
     fn test_default() {
         let c = ParagraphProperty::new();
         let b = c.build();
-        assert_eq!(str::from_utf8(&b).unwrap(), r#"<w:pPr><w:rPr /></w:pPr>"#);
+        assert_xml_eq(str::from_utf8(&b).unwrap(), r#"<w:pPr><w:rPr /></w:pPr>"#);
     }
 
     #[test]
@@ -279,7 +279,7 @@ mod tests {
         let c = ParagraphProperty::new().bidi(true);
         let b = c.build();
         println!("-----Test bidi: {}", str::from_utf8(&b).unwrap());
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<w:pPr><w:rPr /><w:bidi /></w:pPr>"#
         );
@@ -288,7 +288,7 @@ mod tests {
     fn test_alignment() {
         let c = ParagraphProperty::new();
         let b = c.align(AlignmentType::Right).build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<w:pPr><w:rPr /><w:jc w:val="right" /></w:pPr>"#
         );
@@ -298,7 +298,7 @@ mod tests {
     fn test_indent() {
         let c = ParagraphProperty::new();
         let b = c.indent(Some(20), None, None, None).build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<w:pPr><w:rPr /><w:ind w:left="20" w:right="0" /></w:pPr>"#
         );
@@ -308,7 +308,7 @@ mod tests {
     fn test_keep_next() {
         let c = ParagraphProperty::new();
         let b = c.keep_next(true).build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<w:pPr><w:rPr /><w:keepNext /></w:pPr>"#
         );
@@ -318,7 +318,7 @@ mod tests {
     fn test_outline_lvl() {
         let props = ParagraphProperty::new();
         let bytes = props.outline_lvl(1).build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&bytes).unwrap(),
             r#"<w:pPr><w:rPr /><w:outlineLvl w:val="1" /></w:pPr>"#
         )
@@ -341,7 +341,7 @@ mod tests {
             .line_rule(LineSpacingType::AtLeast)
             .line(100);
         let bytes = props.line_spacing(spacing).build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&bytes).unwrap(),
             r#"<w:pPr><w:rPr /><w:spacing w:line="100" w:lineRule="atLeast" /></w:pPr>"#
         )
@@ -351,7 +351,7 @@ mod tests {
     fn test_shading() {
         let props = ParagraphProperty::new().shading(Shading::new().fill("F0F0F0"));
         let bytes = props.build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&bytes).unwrap(),
             r#"<w:pPr><w:rPr /><w:shd w:val="clear" w:color="auto" w:fill="F0F0F0" /></w:pPr>"#
         );
@@ -364,7 +364,7 @@ mod tests {
             ..Default::default()
         });
         let bytes = props.build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&bytes).unwrap(),
             r#"<w:pPr><w:rPr /><w:sectPr><w:pgSz w:w="11906" w:h="16838" /><w:pgMar w:top="1985" w:right="1701" w:bottom="1701" w:left="1701" w:header="851" w:footer="992" w:gutter="0" /><w:cols w:space="425" w:num="1" /><w:type w:val="nextPage" /></w:sectPr></w:pPr>"#
         )

--- a/docx-core/src/documents/elements/paragraph_property_change.rs
+++ b/docx-core/src/documents/elements/paragraph_property_change.rs
@@ -65,9 +65,9 @@ impl BuildXML for ParagraphPropertyChange {
 #[cfg(test)]
 mod tests {
 
+    use crate::xml::test_utils::assert_xml_eq;
+
     use super::*;
-    #[cfg(test)]
-    use pretty_assertions::assert_eq;
     use std::str;
 
     #[test]
@@ -75,7 +75,7 @@ mod tests {
         let b = ParagraphPropertyChange::new()
             .property(ParagraphProperty::new())
             .build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<w:pPrChange w:id="123" w:author="unnamed" w:date="1970-01-01T00:00:00Z"><w:pPr><w:rPr /></w:pPr></w:pPrChange>"#
         );

--- a/docx-core/src/documents/elements/paragraph_property_default.rs
+++ b/docx-core/src/documents/elements/paragraph_property_default.rs
@@ -47,19 +47,17 @@ impl BuildXML for ParagraphPropertyDefault {
     }
 }
 
+#[cfg(test)]
 mod tests {
+    use crate::xml::test_utils::assert_xml_eq;
 
-    #[allow(unused_imports)]
     use super::*;
-
-    #[cfg(test)]
-    use pretty_assertions::assert_eq;
 
     #[test]
     fn test_build() {
         let c = ParagraphPropertyDefault::new();
         let b = c.build();
-        assert_eq!(
+        assert_xml_eq(
             std::str::from_utf8(&b).unwrap(),
             r#"<w:pPrDefault><w:pPr><w:rPr /></w:pPr></w:pPrDefault>"#
         );

--- a/docx-core/src/documents/elements/paragraph_style.rs
+++ b/docx-core/src/documents/elements/paragraph_style.rs
@@ -60,7 +60,6 @@ impl Serialize for ParagraphStyle {
 mod tests {
 
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 

--- a/docx-core/src/documents/elements/pic.rs
+++ b/docx-core/src/documents/elements/pic.rs
@@ -250,15 +250,15 @@ impl BuildXML for Pic {
 #[cfg(test)]
 mod tests {
 
+    use crate::xml::test_utils::assert_xml_eq;
+
     use super::*;
-    #[cfg(test)]
-    use pretty_assertions::assert_eq;
     use std::str;
 
     #[test]
     fn test_pic_build() {
         let b = Pic::new_with_dimensions(Vec::new(), 320, 240).build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<pic:pic xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture"><pic:nvPicPr><pic:cNvPr id="0" name="" /><pic:cNvPicPr><a:picLocks noChangeAspect="1" noChangeArrowheads="1" /></pic:cNvPicPr></pic:nvPicPr><pic:blipFill><a:blip r:embed="rIdImage123" /><a:srcRect /><a:stretch><a:fillRect /></a:stretch></pic:blipFill><pic:spPr bwMode="auto"><a:xfrm rot="0"><a:off x="0" y="0" /><a:ext cx="3048000" cy="2286000" /></a:xfrm><a:prstGeom prst="rect"><a:avLst /></a:prstGeom></pic:spPr></pic:pic>"#
         );

--- a/docx-core/src/documents/elements/q_format.rs
+++ b/docx-core/src/documents/elements/q_format.rs
@@ -30,7 +30,6 @@ impl BuildXML for QFormat {
 mod tests {
 
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 

--- a/docx-core/src/documents/elements/run.rs
+++ b/docx-core/src/documents/elements/run.rs
@@ -422,15 +422,16 @@ impl BuildXML for Run {
 #[cfg(test)]
 mod tests {
 
+    use crate::xml::test_utils::assert_xml_eq;
+
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 
     #[test]
     fn test_build() {
         let b = Run::new().add_text("Hello").build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<w:r><w:rPr /><w:t xml:space="preserve">Hello</w:t></w:r>"#
         );
@@ -439,7 +440,7 @@ mod tests {
     #[test]
     fn test_underline() {
         let b = Run::new().add_text("Hello").underline("single").build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<w:r><w:rPr><w:u w:val="single" /></w:rPr><w:t xml:space="preserve">Hello</w:t></w:r>"#
         );
@@ -448,7 +449,7 @@ mod tests {
     #[test]
     fn test_strike() {
         let b = Run::new().add_text("Hello").strike().build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<w:r><w:rPr><w:strike /></w:rPr><w:t xml:space="preserve">Hello</w:t></w:r>"#
         );

--- a/docx-core/src/documents/elements/run_fonts.rs
+++ b/docx-core/src/documents/elements/run_fonts.rs
@@ -112,7 +112,6 @@ impl BuildXML for RunFonts {
 mod tests {
 
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 

--- a/docx-core/src/documents/elements/run_property.rs
+++ b/docx-core/src/documents/elements/run_property.rs
@@ -277,16 +277,16 @@ impl BuildXML for RunProperty {
 #[cfg(test)]
 mod tests {
 
+    use crate::xml::test_utils::assert_xml_eq;
+
     use super::*;
-    #[cfg(test)]
-    use pretty_assertions::assert_eq;
     use std::str;
 
     #[test]
     fn test_size() {
         let c = RunProperty::new().size(10).color("FFFFFF");
         let b = c.build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<w:rPr><w:sz w:val="10" /><w:szCs w:val="10" /><w:color w:val="FFFFFF" /></w:rPr>"#
         );

--- a/docx-core/src/documents/elements/run_property_default.rs
+++ b/docx-core/src/documents/elements/run_property_default.rs
@@ -61,7 +61,6 @@ impl BuildXML for RunPropertyDefault {
 mod tests {
 
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 

--- a/docx-core/src/documents/elements/run_style.rs
+++ b/docx-core/src/documents/elements/run_style.rs
@@ -48,7 +48,6 @@ impl Serialize for RunStyle {
 mod tests {
 
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 

--- a/docx-core/src/documents/elements/section.rs
+++ b/docx-core/src/documents/elements/section.rs
@@ -247,16 +247,16 @@ impl BuildXML for Section {
 #[cfg(test)]
 mod tests {
 
+    use crate::xml::test_utils::assert_xml_eq;
+
     use super::*;
-    #[cfg(test)]
-    use pretty_assertions::assert_eq;
     use std::str;
 
     #[test]
     fn test_section_property_default() {
         let c = Section::new();
         let b = c.build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<w:p w14:paraId="12345678"><w:pPr><w:sectPr><w:pgSz w:w="11906" w:h="16838" /><w:pgMar w:top="1985" w:right="1701" w:bottom="1701" w:left="1701" w:header="851" w:footer="992" w:gutter="0" /><w:cols w:space="425" w:num="1" /></w:sectPr></w:pPr></w:p>"#
         );
@@ -267,7 +267,7 @@ mod tests {
         let c =
             Section::new().add_paragraph(Paragraph::new().add_run(Run::new().add_text("Hello")));
         let b = c.build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<w:p w14:paraId="12345678"><w:pPr><w:rPr /></w:pPr><w:r><w:rPr /><w:t xml:space="preserve">Hello</w:t></w:r></w:p><w:p w14:paraId="12345678"><w:pPr><w:sectPr><w:pgSz w:w="11906" w:h="16838" /><w:pgMar w:top="1985" w:right="1701" w:bottom="1701" w:left="1701" w:header="851" w:footer="992" w:gutter="0" /><w:cols w:space="425" w:num="1" /></w:sectPr></w:pPr></w:p>"#
         );

--- a/docx-core/src/documents/elements/section_property.rs
+++ b/docx-core/src/documents/elements/section_property.rs
@@ -248,9 +248,9 @@ impl BuildXML for SectionProperty {
 #[cfg(test)]
 mod tests {
 
+    use crate::xml::test_utils::assert_xml_eq;
+
     use super::*;
-    #[cfg(test)]
-    use pretty_assertions::assert_eq;
     use std::str;
 
     #[test]
@@ -258,7 +258,7 @@ mod tests {
         let mut c = SectionProperty::new();
         c = c.text_direction("tbRl".to_string());
         let b = c.build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<w:sectPr><w:pgSz w:w="11906" w:h="16838" /><w:pgMar w:top="1985" w:right="1701" w:bottom="1701" w:left="1701" w:header="851" w:footer="992" w:gutter="0" /><w:cols w:space="425" w:num="1" /><w:textDirection w:val="tbRl" /></w:sectPr>"#
         )
@@ -268,7 +268,7 @@ mod tests {
     fn test_section_property_default() {
         let c = SectionProperty::new();
         let b = c.build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<w:sectPr><w:pgSz w:w="11906" w:h="16838" /><w:pgMar w:top="1985" w:right="1701" w:bottom="1701" w:left="1701" w:header="851" w:footer="992" w:gutter="0" /><w:cols w:space="425" w:num="1" /></w:sectPr>"#
         );
@@ -278,7 +278,7 @@ mod tests {
     fn test_section_property_with_footer() {
         let c = SectionProperty::new().footer(Footer::new(), "rId6");
         let b = c.build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<w:sectPr><w:pgSz w:w="11906" w:h="16838" /><w:pgMar w:top="1985" w:right="1701" w:bottom="1701" w:left="1701" w:header="851" w:footer="992" w:gutter="0" /><w:cols w:space="425" w:num="1" /><w:footerReference w:type="default" r:id="rId6" /></w:sectPr>"#
         );
@@ -288,7 +288,7 @@ mod tests {
     fn test_section_property_with_title_pf() {
         let c = SectionProperty::new().title_pg();
         let b = c.build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<w:sectPr><w:pgSz w:w="11906" w:h="16838" /><w:pgMar w:top="1985" w:right="1701" w:bottom="1701" w:left="1701" w:header="851" w:footer="992" w:gutter="0" /><w:cols w:space="425" w:num="1" /><w:titlePg /></w:sectPr>"#
         );

--- a/docx-core/src/documents/elements/start.rs
+++ b/docx-core/src/documents/elements/start.rs
@@ -37,7 +37,6 @@ impl Serialize for Start {
 mod tests {
 
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 

--- a/docx-core/src/documents/elements/stretch.rs
+++ b/docx-core/src/documents/elements/stretch.rs
@@ -37,7 +37,6 @@ impl Serialize for Stretch {
 mod tests {
 
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 

--- a/docx-core/src/documents/elements/structured_data_tag.rs
+++ b/docx-core/src/documents/elements/structured_data_tag.rs
@@ -172,9 +172,9 @@ impl BuildXML for StructuredDataTag {
 #[cfg(test)]
 mod tests {
 
+    use crate::xml::test_utils::assert_xml_eq;
+
     use super::*;
-    #[cfg(test)]
-    use pretty_assertions::assert_eq;
     use std::str;
 
     #[test]
@@ -183,7 +183,7 @@ mod tests {
             .data_binding(DataBinding::new().xpath("root/hello"))
             .add_run(Run::new().add_text("Hello"))
             .build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<w:sdt><w:sdtPr><w:rPr /><w:dataBinding w:xpath="root/hello" /></w:sdtPr><w:sdtContent><w:r><w:rPr /><w:t xml:space="preserve">Hello</w:t></w:r></w:sdtContent></w:sdt>"#
         );

--- a/docx-core/src/documents/elements/structured_data_tag_property.rs
+++ b/docx-core/src/documents/elements/structured_data_tag_property.rs
@@ -59,7 +59,6 @@ impl BuildXML for StructuredDataTagProperty {
 mod tests {
 
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 

--- a/docx-core/src/documents/elements/style.rs
+++ b/docx-core/src/documents/elements/style.rs
@@ -416,16 +416,16 @@ impl BuildXML for Style {
 #[cfg(test)]
 mod tests {
 
+    use crate::xml::test_utils::assert_xml_eq;
+
     use super::*;
-    #[cfg(test)]
-    use pretty_assertions::assert_eq;
     use std::str;
 
     #[test]
     fn test_build() {
         let c = Style::new("Heading", StyleType::Paragraph).name("Heading1");
         let b = c.build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<w:style w:type="paragraph" w:styleId="Heading"><w:name w:val="Heading1" /><w:rPr /><w:pPr><w:rPr /></w:pPr><w:qFormat /></w:style>"#
         );
@@ -440,7 +440,7 @@ mod tests {
             .semi_hidden()
             .unhide_when_used();
         let b = c.build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<w:style w:type="paragraph" w:styleId="MyStyle"><w:name w:val="My Style" /><w:rPr /><w:pPr><w:rPr /></w:pPr><w:uiPriority w:val="99" /><w:semiHidden /><w:unhideWhenUsed /></w:style>"#
         );

--- a/docx-core/src/documents/elements/sz.rs
+++ b/docx-core/src/documents/elements/sz.rs
@@ -37,7 +37,6 @@ impl Serialize for Sz {
 mod tests {
 
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 

--- a/docx-core/src/documents/elements/sz_cs.rs
+++ b/docx-core/src/documents/elements/sz_cs.rs
@@ -36,7 +36,6 @@ impl Serialize for SzCs {
 mod tests {
 
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 

--- a/docx-core/src/documents/elements/table.rs
+++ b/docx-core/src/documents/elements/table.rs
@@ -160,15 +160,16 @@ impl Serialize for TableChild {
 #[cfg(test)]
 mod tests {
 
+    use crate::xml::test_utils::assert_xml_eq;
+
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 
     #[test]
     fn test_table() {
         let b = Table::new(vec![TableRow::new(vec![])]).build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<w:tbl><w:tblPr><w:tblW w:w="0" w:type="auto" /><w:jc w:val="left" /><w:tblBorders><w:top w:val="single" w:sz="2" w:space="0" w:color="000000" /><w:left w:val="single" w:sz="2" w:space="0" w:color="000000" /><w:bottom w:val="single" w:sz="2" w:space="0" w:color="000000" /><w:right w:val="single" w:sz="2" w:space="0" w:color="000000" /><w:insideH w:val="single" w:sz="2" w:space="0" w:color="000000" /><w:insideV w:val="single" w:sz="2" w:space="0" w:color="000000" /></w:tblBorders></w:tblPr><w:tblGrid /><w:tr><w:trPr /></w:tr></w:tbl>"#
         );
@@ -179,7 +180,7 @@ mod tests {
         let b = Table::new(vec![TableRow::new(vec![])])
             .set_grid(vec![100, 200])
             .build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<w:tbl><w:tblPr><w:tblW w:w="0" w:type="auto" /><w:jc w:val="left" /><w:tblBorders><w:top w:val="single" w:sz="2" w:space="0" w:color="000000" /><w:left w:val="single" w:sz="2" w:space="0" w:color="000000" /><w:bottom w:val="single" w:sz="2" w:space="0" w:color="000000" /><w:right w:val="single" w:sz="2" w:space="0" w:color="000000" /><w:insideH w:val="single" w:sz="2" w:space="0" w:color="000000" /><w:insideV w:val="single" w:sz="2" w:space="0" w:color="000000" /></w:tblBorders></w:tblPr><w:tblGrid><w:gridCol w:w="100" w:type="dxa" /><w:gridCol w:w="200" w:type="dxa" /></w:tblGrid><w:tr><w:trPr /></w:tr></w:tbl>"#
         );

--- a/docx-core/src/documents/elements/table_borders.rs
+++ b/docx-core/src/documents/elements/table_borders.rs
@@ -175,15 +175,15 @@ impl BuildXML for TableBorders {
 #[cfg(test)]
 mod tests {
 
+    use crate::xml::test_utils::assert_xml_eq;
+
     use super::*;
-    #[cfg(test)]
-    use pretty_assertions::assert_eq;
     use std::str;
 
     #[test]
     fn test_table_borders() {
         let b = TableBorders::new().build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<w:tblBorders><w:top w:val="single" w:sz="2" w:space="0" w:color="000000" /><w:left w:val="single" w:sz="2" w:space="0" w:color="000000" /><w:bottom w:val="single" w:sz="2" w:space="0" w:color="000000" /><w:right w:val="single" w:sz="2" w:space="0" w:color="000000" /><w:insideH w:val="single" w:sz="2" w:space="0" w:color="000000" /><w:insideV w:val="single" w:sz="2" w:space="0" w:color="000000" /></w:tblBorders>"#
         );
@@ -195,7 +195,7 @@ mod tests {
             .set(TableBorder::new(TableBorderPosition::Left).color("AAAAAA"))
             .clear(TableBorderPosition::Top)
             .build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<w:tblBorders><w:top w:val="nil" w:sz="2" w:space="0" w:color="000000" /><w:left w:val="single" w:sz="2" w:space="0" w:color="AAAAAA" /><w:bottom w:val="single" w:sz="2" w:space="0" w:color="000000" /><w:right w:val="single" w:sz="2" w:space="0" w:color="000000" /><w:insideH w:val="single" w:sz="2" w:space="0" w:color="000000" /><w:insideV w:val="single" w:sz="2" w:space="0" w:color="000000" /></w:tblBorders>"#
         );

--- a/docx-core/src/documents/elements/table_cell.rs
+++ b/docx-core/src/documents/elements/table_cell.rs
@@ -183,15 +183,16 @@ impl BuildXML for TableCell {
 #[cfg(test)]
 mod tests {
 
+    use crate::xml::test_utils::assert_xml_eq;
+
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 
     #[test]
     fn test_cell() {
         let b = TableCell::new().build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<w:tc><w:tcPr /><w:p w14:paraId="12345678"><w:pPr><w:rPr /></w:pPr></w:p></w:tc>"#
         );
@@ -202,7 +203,7 @@ mod tests {
         let b = TableCell::new()
             .add_paragraph(Paragraph::new().add_run(Run::new().add_text("Hello")))
             .build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<w:tc><w:tcPr /><w:p w14:paraId="12345678"><w:pPr><w:rPr /></w:pPr><w:r><w:rPr /><w:t xml:space="preserve">Hello</w:t></w:r></w:p></w:tc>"#
         );

--- a/docx-core/src/documents/elements/table_cell_margins.rs
+++ b/docx-core/src/documents/elements/table_cell_margins.rs
@@ -86,15 +86,15 @@ impl BuildXML for TableCellMargins {
 #[cfg(test)]
 mod tests {
 
+    use crate::xml::test_utils::assert_xml_eq;
+
     use super::*;
-    #[cfg(test)]
-    use pretty_assertions::assert_eq;
     use std::str;
 
     #[test]
     fn test_table_cell_margin() {
         let b = TableCellMargins::new().build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<w:tblCellMar><w:top w:w="0" w:type="dxa" /><w:left w:w="55" w:type="dxa" /><w:bottom w:w="0" w:type="dxa" /><w:right w:w="55" w:type="dxa" /></w:tblCellMar>"#
         );
@@ -103,7 +103,7 @@ mod tests {
     #[test]
     fn test_table_cell_margin_setter() {
         let b = TableCellMargins::new().margin(10, 20, 30, 40).build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<w:tblCellMar><w:top w:w="10" w:type="dxa" /><w:left w:w="40" w:type="dxa" /><w:bottom w:w="30" w:type="dxa" /><w:right w:w="20" w:type="dxa" /></w:tblCellMar>"#
         );

--- a/docx-core/src/documents/elements/table_cell_property.rs
+++ b/docx-core/src/documents/elements/table_cell_property.rs
@@ -148,7 +148,6 @@ impl BuildXML for TableCellProperty {
 mod tests {
 
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 

--- a/docx-core/src/documents/elements/table_cell_width.rs
+++ b/docx-core/src/documents/elements/table_cell_width.rs
@@ -33,7 +33,6 @@ impl BuildXML for TableCellWidth {
 mod tests {
 
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 

--- a/docx-core/src/documents/elements/table_grid.rs
+++ b/docx-core/src/documents/elements/table_grid.rs
@@ -30,15 +30,15 @@ impl BuildXML for TableGrid {
 #[cfg(test)]
 mod tests {
 
+    use crate::xml::test_utils::assert_xml_eq;
+
     use super::*;
-    #[cfg(test)]
-    use pretty_assertions::assert_eq;
     use std::str;
 
     #[test]
     fn test_table_indent() {
         let b = TableGrid::new(vec![100, 200]).build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<w:tblGrid><w:gridCol w:w="100" w:type="dxa" /><w:gridCol w:w="200" w:type="dxa" /></w:tblGrid>"#
         );

--- a/docx-core/src/documents/elements/table_indent.rs
+++ b/docx-core/src/documents/elements/table_indent.rs
@@ -33,7 +33,6 @@ impl BuildXML for TableIndent {
 mod tests {
 
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 

--- a/docx-core/src/documents/elements/table_of_contents.rs
+++ b/docx-core/src/documents/elements/table_of_contents.rs
@@ -323,15 +323,15 @@ impl BuildXML for TableOfContents {
 #[cfg(test)]
 mod tests {
 
+    use crate::xml::test_utils::assert_xml_eq;
+
     use super::*;
-    #[cfg(test)]
-    use pretty_assertions::assert_eq;
     use std::str;
 
     #[test]
     fn test_toc() {
         let b = TableOfContents::new().heading_styles_range(1, 3).build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<w:sdt><w:sdtPr><w:rPr /></w:sdtPr><w:sdtContent><w:p w14:paraId="12345678"><w:pPr><w:rPr /></w:pPr><w:r><w:rPr /><w:fldChar w:fldCharType="begin" w:dirty="true" /><w:instrText>TOC \o &quot;1-3&quot;</w:instrText><w:fldChar w:fldCharType="separate" w:dirty="false" /></w:r></w:p><w:p w14:paraId="12345678"><w:pPr><w:rPr /></w:pPr><w:r><w:rPr /><w:fldChar w:fldCharType="end" w:dirty="false" /></w:r></w:p></w:sdtContent></w:sdt>"#
         );
@@ -343,7 +343,7 @@ mod tests {
             .without_sdt()
             .heading_styles_range(1, 3)
             .build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<w:p w14:paraId="12345678"><w:pPr><w:rPr /></w:pPr><w:r><w:rPr /><w:fldChar w:fldCharType="begin" w:dirty="true" /><w:instrText>TOC \o &quot;1-3&quot;</w:instrText><w:fldChar w:fldCharType="separate" w:dirty="false" /></w:r></w:p><w:p w14:paraId="12345678"><w:pPr><w:rPr /></w:pPr><w:r><w:rPr /><w:fldChar w:fldCharType="end" w:dirty="false" /></w:r></w:p>"#
         );
@@ -356,7 +356,7 @@ mod tests {
             .heading_styles_range(1, 3)
             .add_items(Paragraph::new().add_run(Run::new().add_text("Hello")))
             .build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<w:sdt><w:sdtPr /><w:sdtContent><w:p w14:paraId="12345678"><w:pPr><w:rPr /></w:pPr><w:r><w:rPr /><w:fldChar w:fldCharType="begin" w:dirty="false" /><w:instrText>TOC \o &quot;1-3&quot;</w:instrText><w:fldChar w:fldCharType="separate" w:dirty="false" /></w:r><w:r><w:rPr /><w:t xml:space="preserve">Hello</w:t></w:r><w:r><w:rPr /><w:fldChar w:fldCharType="end" w:dirty="false" /></w:r></w:p></w:sdtContent></w:sdt>"#
         );

--- a/docx-core/src/documents/elements/table_position_property.rs
+++ b/docx-core/src/documents/elements/table_position_property.rs
@@ -88,7 +88,6 @@ impl BuildXML for TablePositionProperty {
 mod tests {
 
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 

--- a/docx-core/src/documents/elements/table_property.rs
+++ b/docx-core/src/documents/elements/table_property.rs
@@ -173,8 +173,9 @@ impl BuildXML for TableProperty {
 #[cfg(test)]
 mod tests {
 
+    use crate::xml::test_utils::assert_xml_eq;
+
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 
@@ -182,7 +183,7 @@ mod tests {
     fn test_default() {
         let c = TableProperty::new();
         let b = c.build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<w:tblPr><w:tblW w:w="0" w:type="auto" /><w:jc w:val="left" /><w:tblBorders><w:top w:val="single" w:sz="2" w:space="0" w:color="000000" /><w:left w:val="single" w:sz="2" w:space="0" w:color="000000" /><w:bottom w:val="single" w:sz="2" w:space="0" w:color="000000" /><w:right w:val="single" w:sz="2" w:space="0" w:color="000000" /><w:insideH w:val="single" w:sz="2" w:space="0" w:color="000000" /><w:insideV w:val="single" w:sz="2" w:space="0" w:color="000000" /></w:tblBorders></w:tblPr>"#
         );

--- a/docx-core/src/documents/elements/table_row.rs
+++ b/docx-core/src/documents/elements/table_row.rs
@@ -121,15 +121,16 @@ impl Serialize for TableRowChild {
 #[cfg(test)]
 mod tests {
 
+    use crate::xml::test_utils::assert_xml_eq;
+
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 
     #[test]
     fn test_row() {
         let b = TableRow::new(vec![TableCell::new()]).build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<w:tr><w:trPr /><w:tc><w:tcPr /><w:p w14:paraId="12345678"><w:pPr><w:rPr /></w:pPr></w:p></w:tc></w:tr>"#
         );
@@ -147,7 +148,7 @@ mod tests {
     #[test]
     fn test_row_cant_split() {
         let b = TableRow::new(vec![TableCell::new()]).cant_split().build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<w:tr><w:trPr><w:cantSplit /></w:trPr><w:tc><w:tcPr /><w:p w14:paraId="12345678"><w:pPr><w:rPr /></w:pPr></w:p></w:tc></w:tr>"#
         );

--- a/docx-core/src/documents/elements/table_row_property.rs
+++ b/docx-core/src/documents/elements/table_row_property.rs
@@ -100,7 +100,6 @@ impl BuildXML for TableRowProperty {
 mod tests {
 
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 

--- a/docx-core/src/documents/elements/table_width.rs
+++ b/docx-core/src/documents/elements/table_width.rs
@@ -33,7 +33,6 @@ impl BuildXML for TableWidth {
 mod tests {
 
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 

--- a/docx-core/src/documents/elements/text.rs
+++ b/docx-core/src/documents/elements/text.rs
@@ -56,7 +56,6 @@ impl Serialize for Text {
 mod tests {
 
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 

--- a/docx-core/src/documents/elements/text_box_content.rs
+++ b/docx-core/src/documents/elements/text_box_content.rs
@@ -91,9 +91,9 @@ impl BuildXML for TextBoxContent {
 #[cfg(test)]
 mod tests {
 
+    use crate::xml::test_utils::assert_xml_eq;
+
     use super::*;
-    #[cfg(test)]
-    use pretty_assertions::assert_eq;
     use std::str;
 
     #[test]
@@ -101,7 +101,7 @@ mod tests {
         let b = TextBoxContent::new()
             .add_paragraph(Paragraph::new())
             .build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<w:txbxContent><w:p w14:paraId="12345678"><w:pPr><w:rPr /></w:pPr></w:p></w:txbxContent>"#
         );

--- a/docx-core/src/documents/elements/underline.rs
+++ b/docx-core/src/documents/elements/underline.rs
@@ -37,7 +37,6 @@ impl Serialize for Underline {
 mod tests {
 
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 

--- a/docx-core/src/documents/elements/v_align.rs
+++ b/docx-core/src/documents/elements/v_align.rs
@@ -40,7 +40,6 @@ impl Serialize for VAlign {
 mod tests {
 
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 

--- a/docx-core/src/documents/elements/vanish.rs
+++ b/docx-core/src/documents/elements/vanish.rs
@@ -35,7 +35,6 @@ impl Serialize for Vanish {
 mod tests {
 
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 

--- a/docx-core/src/documents/elements/vertical_merge.rs
+++ b/docx-core/src/documents/elements/vertical_merge.rs
@@ -40,7 +40,6 @@ impl Serialize for VMerge {
 mod tests {
 
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 

--- a/docx-core/src/documents/elements/wp_anchor.rs
+++ b/docx-core/src/documents/elements/wp_anchor.rs
@@ -50,7 +50,6 @@ impl BuildXML for WpAnchor {
 mod tests {
 
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 

--- a/docx-core/src/documents/elements/wps_text_box.rs
+++ b/docx-core/src/documents/elements/wps_text_box.rs
@@ -42,16 +42,16 @@ impl BuildXML for WpsTextBox {
 #[cfg(test)]
 mod tests {
 
+    use crate::xml::test_utils::assert_xml_eq;
+
     use super::*;
-    #[cfg(test)]
-    use pretty_assertions::assert_eq;
     use std::str;
 
     #[test]
     fn test_wp_text_box_build() {
         let c = TextBoxContent::new().add_paragraph(Paragraph::new());
         let b = WpsTextBox::new().add_content(c).build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<wps:txbx><w:txbxContent><w:p w14:paraId="12345678"><w:pPr><w:rPr /></w:pPr></w:p></w:txbxContent></wps:txbx>"#
         );

--- a/docx-core/src/documents/elements/zoom.rs
+++ b/docx-core/src/documents/elements/zoom.rs
@@ -39,7 +39,6 @@ impl Serialize for Zoom {
 mod tests {
 
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 

--- a/docx-core/src/documents/font_table.rs
+++ b/docx-core/src/documents/font_table.rs
@@ -38,15 +38,16 @@ impl BuildXML for FontTable {
 #[cfg(test)]
 mod tests {
 
+    use crate::xml::test_utils::assert_xml_eq;
+
     use super::*;
-    use pretty_assertions::assert_str_eq;
     use std::str;
 
     #[test]
     fn test_settings() {
         let c = FontTable::new();
         let b = c.build();
-        assert_str_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:fonts xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><w:font w:name="Times New Roman"><w:charset w:val="00" /><w:family w:val="roman" /><w:pitch w:val="variable" /></w:font><w:font w:name="Symbol"><w:charset w:val="02" /><w:family w:val="roman" /><w:pitch w:val="variable" /></w:font><w:font w:name="Arial"><w:charset w:val="00" /><w:family w:val="swiss" /><w:pitch w:val="variable" /></w:font></w:fonts>"#
         );

--- a/docx-core/src/documents/footer.rs
+++ b/docx-core/src/documents/footer.rs
@@ -101,16 +101,16 @@ impl BuildXML for Footer {
 #[cfg(test)]
 mod tests {
 
+    use crate::xml::test_utils::assert_xml_eq;
+
     use super::*;
-    #[cfg(test)]
-    use pretty_assertions::assert_eq;
     use std::str;
 
     #[test]
     fn test_settings() {
         let c = Footer::new();
         let b = c.build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:ftr xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w10="urn:schemas-microsoft-com:office:word" xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing" xmlns:wps="http://schemas.microsoft.com/office/word/2010/wordprocessingShape" xmlns:wpg="http://schemas.microsoft.com/office/word/2010/wordprocessingGroup" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:wp14="http://schemas.microsoft.com/office/word/2010/wordprocessingDrawing" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml" mc:Ignorable="w14 wp14" />"#
         );

--- a/docx-core/src/documents/footnotes.rs
+++ b/docx-core/src/documents/footnotes.rs
@@ -38,15 +38,15 @@ impl BuildXML for Footnotes {
 #[cfg(test)]
 mod tests {
 
+    use crate::xml::test_utils::assert_xml_eq;
+
     use super::*;
-    #[cfg(test)]
-    use pretty_assertions::assert_eq;
     use std::str;
 
     #[test]
     fn test_footnotes() {
         let b = Footnotes::new().build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:footnotes xmlns:wpc="http://schemas.microsoft.com/office/word/2010/wordprocessingCanvas" xmlns:cx="http://schemas.microsoft.com/office/drawing/2014/chartex" xmlns:cx1="http://schemas.microsoft.com/office/drawing/2015/9/8/chartex" xmlns:cx2="http://schemas.microsoft.com/office/drawing/2015/10/21/chartex" xmlns:cx3="http://schemas.microsoft.com/office/drawing/2016/5/9/chartex" xmlns:cx4="http://schemas.microsoft.com/office/drawing/2016/5/10/chartex" xmlns:cx5="http://schemas.microsoft.com/office/drawing/2016/5/11/chartex" xmlns:cx6="http://schemas.microsoft.com/office/drawing/2016/5/12/chartex" xmlns:cx7="http://schemas.microsoft.com/office/drawing/2016/5/13/chartex" xmlns:cx8="http://schemas.microsoft.com/office/drawing/2016/5/14/chartex" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:aink="http://schemas.microsoft.com/office/drawing/2016/ink" xmlns:am3d="http://schemas.microsoft.com/office/drawing/2017/model3d" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:oel="http://schemas.microsoft.com/office/2019/extlst" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:m="http://schemas.openxmlformats.org/officeDocument/2006/math" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:wp14="http://schemas.microsoft.com/office/word/2010/wordprocessingDrawing" xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing" xmlns:w10="urn:schemas-microsoft-com:office:word" xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml" xmlns:w15="http://schemas.microsoft.com/office/word/2012/wordml" xmlns:w16cex="http://schemas.microsoft.com/office/word/2018/wordml/cex" xmlns:w16cid="http://schemas.microsoft.com/office/word/2016/wordml/cid" xmlns:w16="http://schemas.microsoft.com/office/word/2018/wordml" xmlns:w16du="http://schemas.microsoft.com/office/word/2023/wordml/word16du" xmlns:w16sdtdh="http://schemas.microsoft.com/office/word/2020/wordml/sdtdatahash" xmlns:w16se="http://schemas.microsoft.com/office/word/2015/wordml/symex" xmlns:wpg="http://schemas.microsoft.com/office/word/2010/wordprocessingGroup" xmlns:wpi="http://schemas.microsoft.com/office/word/2010/wordprocessingInk" xmlns:wne="http://schemas.microsoft.com/office/word/2006/wordml" xmlns:wps="http://schemas.microsoft.com/office/word/2010/wordprocessingShape" mc:Ignorable="w14 w15 w16se w16cid w16 w16cex w16sdtdh w16du wp14" />"#
         );

--- a/docx-core/src/documents/header.rs
+++ b/docx-core/src/documents/header.rs
@@ -101,16 +101,16 @@ impl BuildXML for Header {
 #[cfg(test)]
 mod tests {
 
+    use crate::xml::test_utils::assert_xml_eq;
+
     use super::*;
-    #[cfg(test)]
-    use pretty_assertions::assert_eq;
     use std::str;
 
     #[test]
     fn test_settings() {
         let c = Header::new();
         let b = c.build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:hdr xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w10="urn:schemas-microsoft-com:office:word" xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing" xmlns:wps="http://schemas.microsoft.com/office/word/2010/wordprocessingShape" xmlns:wpg="http://schemas.microsoft.com/office/word/2010/wordprocessingGroup" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:wp14="http://schemas.microsoft.com/office/word/2010/wordprocessingDrawing" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml" mc:Ignorable="w14 wp14" />"#
         );

--- a/docx-core/src/documents/rels.rs
+++ b/docx-core/src/documents/rels.rs
@@ -79,16 +79,16 @@ impl BuildXML for Rels {
 #[cfg(test)]
 mod tests {
 
+    use crate::xml::test_utils::assert_xml_eq;
+
     use super::*;
-    #[cfg(test)]
-    use pretty_assertions::assert_eq;
     use std::str;
 
     #[test]
     fn test_build() {
         let c = Rels::new().set_default();
         let b = c.build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<?xml version="1.0" encoding="UTF-8"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties" Target="docProps/core.xml" /><Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/extended-properties" Target="docProps/app.xml" /><Relationship Id="rId3" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml" /><Relationship Id="rId4" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/custom-properties" Target="docProps/custom.xml" /></Relationships>"#
         );

--- a/docx-core/src/documents/settings.rs
+++ b/docx-core/src/documents/settings.rs
@@ -136,15 +136,16 @@ impl BuildXML for Settings {
 
 #[cfg(test)]
 mod tests {
+    use crate::xml::test_utils::assert_xml_eq;
+
     use super::*;
-    use pretty_assertions::assert_eq;
     use std::str;
 
     #[test]
     fn test_settings() {
         let c = Settings::new();
         let b = c.build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:settings xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml" xmlns:w15="http://schemas.microsoft.com/office/word/2012/wordml"><w:defaultTabStop w:val="840" /><w:zoom w:percent="100" /><w:compat><w:spaceForUL /><w:balanceSingleByteDoubleByteWidth /><w:doNotLeaveBackslashAlone /><w:ulTrailSpace /><w:doNotExpandShiftReturn /><w:useFELayout /><w:compatSetting w:name="compatibilityMode" w:uri="http://schemas.microsoft.com/office/word" w:val="15" /><w:compatSetting w:name="overrideTableStyleFontSizeAndJustification" w:uri="http://schemas.microsoft.com/office/word" w:val="1" /><w:compatSetting w:name="enableOpenTypeFeatures" w:uri="http://schemas.microsoft.com/office/word" w:val="1" /><w:compatSetting w:name="doNotFlipMirrorIndents" w:uri="http://schemas.microsoft.com/office/word" w:val="1" /><w:compatSetting w:name="differentiateMultirowTableHeaders" w:uri="http://schemas.microsoft.com/office/word" w:val="1" /><w:compatSetting w:name="useWord2013TrackBottomHyphenation" w:uri="http://schemas.microsoft.com/office/word" w:val="0" /></w:compat></w:settings>"#
         );

--- a/docx-core/src/documents/styles.rs
+++ b/docx-core/src/documents/styles.rs
@@ -96,8 +96,7 @@ impl BuildXML for Styles {
 mod tests {
 
     use super::*;
-    use crate::types::StyleType;
-    #[cfg(test)]
+    use crate::{types::StyleType, xml::test_utils::assert_xml_eq};
     use pretty_assertions::assert_eq;
     use std::str;
 
@@ -106,7 +105,7 @@ mod tests {
         let c =
             Styles::new().add_style(Style::new("Title", StyleType::Paragraph).name("TitleName"));
         let b = c.build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<w:styles xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml" xmlns:w15="http://schemas.microsoft.com/office/word/2012/wordml" mc:Ignorable="w14 w15"><w:docDefaults><w:rPrDefault><w:rPr /></w:rPrDefault><w:pPrDefault><w:pPr><w:rPr /></w:pPr></w:pPrDefault></w:docDefaults><w:style w:type="paragraph" w:styleId="Normal"><w:name w:val="Normal" /><w:rPr /><w:pPr><w:rPr /></w:pPr><w:qFormat /></w:style><w:style w:type="paragraph" w:styleId="Title"><w:name w:val="TitleName" /><w:rPr /><w:pPr><w:rPr /></w:pPr><w:qFormat /></w:style></w:styles>"#
         );
@@ -126,7 +125,7 @@ mod tests {
                 ),
         );
         let b = c.build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<w:styles xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml" xmlns:w15="http://schemas.microsoft.com/office/word/2012/wordml" mc:Ignorable="w14 w15"><w:docDefaults><w:rPrDefault><w:rPr /></w:rPrDefault><w:pPrDefault><w:pPr><w:rPr /></w:pPr></w:pPrDefault></w:docDefaults><w:style w:type="paragraph" w:styleId="Normal"><w:name w:val="Normal" /><w:rPr /><w:pPr><w:rPr /></w:pPr><w:qFormat /></w:style><w:style w:type="table" w:styleId="Table"><w:name w:val="Table Style" /><w:rPr /><w:pPr><w:rPr /></w:pPr><w:tcPr /><w:tblPr><w:tblW w:w="0" w:type="auto" /><w:jc w:val="left" /><w:tblBorders><w:top w:val="single" w:sz="2" w:space="0" w:color="000000" /><w:left w:val="single" w:sz="2" w:space="0" w:color="000000" /><w:bottom w:val="single" w:sz="2" w:space="0" w:color="000000" /><w:right w:val="single" w:sz="2" w:space="0" w:color="000000" /><w:insideH w:val="single" w:sz="2" w:space="0" w:color="000000" /><w:insideV w:val="single" w:sz="2" w:space="0" w:color="000000" /></w:tblBorders><w:tblCellMar><w:top w:w="0" w:type="dxa" /><w:left w:w="108" w:type="dxa" /><w:bottom w:w="0" w:type="dxa" /><w:right w:w="108" w:type="dxa" /></w:tblCellMar></w:tblPr><w:qFormat /></w:style></w:styles>"#
         );

--- a/docx-core/src/documents/taskpanes.rs
+++ b/docx-core/src/documents/taskpanes.rs
@@ -35,16 +35,16 @@ impl BuildXML for Taskpanes {
 #[cfg(test)]
 mod tests {
 
+    use crate::xml::test_utils::assert_xml_eq;
+
     use super::*;
-    #[cfg(test)]
-    use pretty_assertions::assert_eq;
     use std::str;
 
     #[test]
     fn test_build() {
         let c = Taskpanes::new();
         let b = c.build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><wetp:taskpanes xmlns:wetp="http://schemas.microsoft.com/office/webextensions/taskpanes/2010/11"><wetp:taskpane dockstate="" visibility="1" width="350" row="1"><wetp:webextensionref xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" r:id="rId1" /></wetp:taskpane></wetp:taskpanes>"#
         );

--- a/docx-core/src/documents/taskpanes_rels.rs
+++ b/docx-core/src/documents/taskpanes_rels.rs
@@ -46,16 +46,16 @@ impl BuildXML for TaskpanesRels {
 #[cfg(test)]
 mod tests {
 
+    use crate::xml::test_utils::assert_xml_eq;
+
     use super::*;
-    #[cfg(test)]
-    use pretty_assertions::assert_eq;
     use std::str;
 
     #[test]
     fn test_build() {
         let c = TaskpanesRels::new().add_rel();
         let b = c.build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.microsoft.com/office/2011/relationships/webextension" Target="webextension1.xml" /></Relationships>"#
         );

--- a/docx-core/src/documents/webextension.rs
+++ b/docx-core/src/documents/webextension.rs
@@ -91,9 +91,9 @@ impl BuildXML for WebExtension {
 #[cfg(test)]
 mod tests {
 
+    use crate::xml::test_utils::assert_xml_eq;
+
     use super::*;
-    #[cfg(test)]
-    use pretty_assertions::assert_eq;
     use std::str;
 
     #[test]
@@ -107,7 +107,7 @@ mod tests {
         )
         .property("hello", "world");
         let b = c.build();
-        assert_eq!(
+        assert_xml_eq(
             str::from_utf8(&b).unwrap(),
             r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><we:webextension xmlns:we="http://schemas.microsoft.com/office/webextensions/webextension/2010/11" id="{7f33b723-fb58-4524-8733-dbedc4b7c095}"><we:reference id="abcd" version="1.0.0.0" store="developer" storeType="Registry" /><we:alternateReferences /><we:properties><we:property name="hello" value="&quot;world&quot;" /></we:properties><we:bindings /><we:snapshot xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" /></we:webextension>"#
         );

--- a/docx-core/src/reader/a_graphic.rs
+++ b/docx-core/src/reader/a_graphic.rs
@@ -39,7 +39,6 @@ impl ElementReader for AGraphic {
 mod tests {
 
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
 
     #[test]

--- a/docx-core/src/reader/footer.rs
+++ b/docx-core/src/reader/footer.rs
@@ -47,9 +47,14 @@ impl FromXML for Footer {
     }
 }
 
-#[test]
-fn test_footer_from_xml() {
-    let xml = r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn test_footer_from_xml() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <w:ftr xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
     xmlns:o="urn:schemas-microsoft-com:office:office"
     xmlns:v="urn:schemas-microsoft-com:vml"
@@ -71,8 +76,9 @@ fn test_footer_from_xml() {
         </w:r>
     </w:p>
 </w:ftr>"#;
-    let h = Footer::from_xml(xml.as_bytes()).unwrap();
-    let expected =
-        Footer::new().add_paragraph(Paragraph::new().add_run(Run::new().add_text("Hello Footer")));
-    assert_eq!(h, expected)
+        let h = Footer::from_xml(xml.as_bytes()).unwrap();
+        let expected = Footer::new()
+            .add_paragraph(Paragraph::new().add_run(Run::new().add_text("Hello Footer")));
+        assert_eq!(h, expected)
+    }
 }

--- a/docx-core/src/reader/header.rs
+++ b/docx-core/src/reader/header.rs
@@ -47,9 +47,14 @@ impl FromXML for Header {
     }
 }
 
-#[test]
-fn test_header_from_xml() {
-    let xml = r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn test_header_from_xml() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <w:hdr xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
     xmlns:o="urn:schemas-microsoft-com:office:office"
     xmlns:v="urn:schemas-microsoft-com:vml"
@@ -71,8 +76,9 @@ fn test_header_from_xml() {
         </w:r>
     </w:p>
 </w:hdr>"#;
-    let h = Header::from_xml(xml.as_bytes()).unwrap();
-    let expected =
-        Header::new().add_paragraph(Paragraph::new().add_run(Run::new().add_text("Hello Header")));
-    assert_eq!(h, expected)
+        let h = Header::from_xml(xml.as_bytes()).unwrap();
+        let expected = Header::new()
+            .add_paragraph(Paragraph::new().add_run(Run::new().add_text("Hello Header")));
+        assert_eq!(h, expected)
+    }
 }

--- a/docx-core/src/reader/numberings.rs
+++ b/docx-core/src/reader/numberings.rs
@@ -128,7 +128,6 @@ mod tests {
 
     use super::*;
     use crate::types::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
 
     #[test]

--- a/docx-core/src/reader/paragraph.rs
+++ b/docx-core/src/reader/paragraph.rs
@@ -109,7 +109,6 @@ mod tests {
 
     use super::*;
     use crate::types::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
 
     #[test]

--- a/docx-core/src/reader/rels.rs
+++ b/docx-core/src/reader/rels.rs
@@ -119,7 +119,6 @@ pub fn read_rels_xml<R: Read>(reader: R, dir: impl AsRef<Path>) -> Result<ReadRe
 mod tests {
 
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
 
     #[test]

--- a/docx-core/src/reader/run.rs
+++ b/docx-core/src/reader/run.rs
@@ -193,7 +193,6 @@ impl ElementReader for Run {
 mod tests {
 
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
 
     #[test]

--- a/docx-core/src/reader/styles.rs
+++ b/docx-core/src/reader/styles.rs
@@ -50,7 +50,6 @@ mod tests {
 
     use super::*;
     use crate::types::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
 
     #[test]

--- a/docx-core/src/reader/table.rs
+++ b/docx-core/src/reader/table.rs
@@ -82,7 +82,6 @@ impl ElementReader for Table {
 mod tests {
 
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
 
     #[test]

--- a/docx-core/src/reader/table_cell.rs
+++ b/docx-core/src/reader/table_cell.rs
@@ -58,7 +58,6 @@ mod tests {
 
     use super::*;
     use crate::types::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
 
     #[test]

--- a/docx-core/src/xml/mod.rs
+++ b/docx-core/src/xml/mod.rs
@@ -1,2 +1,4 @@
 pub mod common;
+#[cfg(test)]
+pub(crate) mod test_utils;
 pub mod writer;

--- a/docx-core/src/xml/test_utils.rs
+++ b/docx-core/src/xml/test_utils.rs
@@ -1,0 +1,32 @@
+pub fn beautify_xml(input: &str) -> String {
+    let mut reader = quick_xml::reader::Reader::from_str(input);
+    reader.config_mut().trim_text(true);
+    let mut writer =
+        quick_xml::writer::Writer::new_with_indent(std::io::Cursor::new(Vec::new()), b' ', 4);
+    let mut buf = Vec::new();
+    loop {
+        match reader.read_event_into(&mut buf).unwrap() {
+            quick_xml::events::Event::Eof => break,
+            event => {
+                writer.write_event(event).unwrap();
+            }
+        }
+        buf.clear();
+    }
+    String::from_utf8(writer.into_inner().into_inner()).unwrap()
+}
+
+#[track_caller]
+pub fn assert_xml_eq(lhs: &str, rhs: &str) {
+    // comparison for humans to look at
+    pretty_assertions::assert_eq!(
+        beautify_xml(lhs),
+        beautify_xml(rhs)
+    );
+
+    // to make sure compact serialization is also as expected
+    pretty_assertions::assert_eq!(
+        lhs,
+        rhs
+    );
+}

--- a/docx-core/src/xml_builder/document.rs
+++ b/docx-core/src/xml_builder/document.rs
@@ -57,7 +57,6 @@ impl<W: Write> XMLBuilder<W> {
 mod tests {
 
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 

--- a/docx-core/src/xml_builder/elements.rs
+++ b/docx-core/src/xml_builder/elements.rs
@@ -767,7 +767,6 @@ impl<W: Write> XMLBuilder<W> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 

--- a/docx-core/src/xml_builder/styles.rs
+++ b/docx-core/src/xml_builder/styles.rs
@@ -38,7 +38,6 @@ impl<W: Write> XMLBuilder<W> {
 mod tests {
 
     use super::*;
-    #[cfg(test)]
     use pretty_assertions::assert_eq;
     use std::str;
 


### PR DESCRIPTION
Also some minor cleanups.

## What does this change?

Introduces `assert_xml_eq` and use it in places, where I judged it helpful.

It beautifies the xml before comparison with pretty_assertions::assert_eq! to get nicer diffs,
where I (and hopefully others) can pinpoint differences more easily.

It also compares the strings directly afterwards, so the compact serialization is also tested.

I understand, that this is mostly a matter of taste, so if you don't like it, just close the MR. No hard feelings :)