### PR TITLE
Fix panic when rebuilding read instruction text

### DIFF
--- a/docx-core/src/documents/elements/run.rs
+++ b/docx-core/src/documents/elements/run.rs
@@ -398,7 +398,11 @@ impl BuildXML for RunChild {
             RunChild::FieldChar(c) => c.build_to(stream),
             RunChild::InstrText(c) => c.build_to(stream),
             RunChild::DeleteInstrText(c) => c.build_to(stream),
-            RunChild::InstrTextString(_) => unreachable!(),
+            RunChild::InstrTextString(instruction) => XMLBuilder::from(stream)
+                .write(XmlEvent::start_element("w:instrText").attr("xml:space", "preserve"))?
+                .plain_text(&crate::escape::escape(instruction))?
+                .close()?
+                .into_inner(),
             RunChild::FootnoteReference(c) => c.build_to(stream),
             RunChild::Shading(s) => s.build_to(stream),
         }

--- a/docx-core/tests/reader.rs
+++ b/docx-core/tests/reader.rs
@@ -2,7 +2,25 @@ use insta::assert_debug_snapshot;
 
 use docx_rs::*;
 use std::fs::*;
-use std::io::{Read, Write};
+use std::io::{Cursor, Read, Write};
+
+#[test]
+pub fn read_and_build_document_with_instr_text() {
+    let input = include_bytes!("../../fixtures/page_num_in_header/page_num_in_header.docx");
+    let document = read_docx(input).unwrap();
+    let mut output = Cursor::new(Vec::new());
+
+    document.build().pack(&mut output).unwrap();
+
+    let mut archive = zip::ZipArchive::new(output).unwrap();
+    let mut header = String::new();
+    archive
+        .by_name("word/header1.xml")
+        .unwrap()
+        .read_to_string(&mut header)
+        .unwrap();
+    assert!(header.contains(r#"<w:instrText xml:space="preserve"> PAGE </w:instrText>"#));
+}
 
 #[test]
 pub fn read_hello() {


### PR DESCRIPTION
## What changed

- Serialize reader-originated `InstrTextString` values back to `w:instrText` instead of entering an `unreachable!()` branch.
- Preserve whitespace and XML-escape the instruction text when writing it.
- Add a regression test that reads the existing page-number fixture, rebuilds and packs it, and verifies the `PAGE` instruction remains in the generated header XML.

## Root cause

The reader stores `w:instrText` contents as `RunChild::InstrTextString`, but the writer treated that reader-only variant as unreachable. Calling `build()` on a document containing fields such as page numbers therefore panicked.

## Impact

Documents read by `read_docx` can now be rebuilt when they contain field instructions, including page numbering, without panicking or dropping the instruction text.

## Validation

- `make test -B`
- `make lint -B`
- `cargo fmt --all -- --check`
- `git diff --check`

Fixes #750
