### PR TITLE
Fix table properties

### DIFF
--- a/docx-core/src/documents/elements/table_property.rs
+++ b/docx-core/src/documents/elements/table_property.rs
@@ -157,12 +157,14 @@ impl BuildXML for TableProperty {
     ) -> crate::xml::writer::Result<crate::xml::writer::EventWriter<W>> {
         XMLBuilder::from(stream)
             .open_table_property()?
+            // If a style is set, it has to come first, otherwise everything
+            // before the style might be ignored by word.
+            .add_optional_child(&self.style)?
             .add_child(&self.width)?
             .add_child(&self.justification)?
             .add_child(&self.borders)?
             .add_optional_child(&self.margins)?
             .add_optional_child(&self.indent)?
-            .add_optional_child(&self.style)?
             .add_optional_child(&self.layout)?
             .add_optional_child(&self.position)?
             .close()?

--- a/docx-core/tests/lib.rs
+++ b/docx-core/tests/lib.rs
@@ -99,6 +99,34 @@ pub fn table() -> Result<(), DocxError> {
 }
 
 #[test]
+pub fn table_with_style_and_indent() -> Result<(), DocxError> {
+    let path = std::path::Path::new("./tests/output/table_with_style_and_indent.docx");
+    let file = std::fs::File::create(path).unwrap();
+
+    let style = Style::new("table_for_test", StyleType::Table).name("table_for_test");
+
+    let table = Table::new(vec![
+        TableRow::new(vec![
+            TableCell::new().add_paragraph(Paragraph::new().add_run(Run::new().add_text("Hello"))),
+            TableCell::new().add_paragraph(Paragraph::new().add_run(Run::new().add_text("World"))),
+        ]),
+        TableRow::new(vec![
+            TableCell::new().add_paragraph(Paragraph::new().add_run(Run::new().add_text("Foo"))),
+            TableCell::new().add_paragraph(Paragraph::new().add_run(Run::new().add_text("Bar"))),
+        ]),
+    ])
+    .style("table_for_test")
+    .indent(1440);
+
+    Docx::new()
+        .add_style(style)
+        .add_table(table)
+        .build()
+        .pack(file)?;
+    Ok(())
+}
+
+#[test]
 pub fn table_with_grid() -> Result<(), DocxError> {
     let path = std::path::Path::new("./tests/output/table_with_grid.docx");
     let file = std::fs::File::create(path).unwrap();


### PR DESCRIPTION
## What does this change?

If a table has a style, serialize it first in the table properties.

Otherwise word might ignore the properties before the style property.

## What can I check for bug fixes?

Run test `table_with_style_and_indent` at e5b2d6a293ec5c191f6bbba0b6f90c4b23400733 and open up `docx-core/tests/output/table_with_style_and_indent.docx` in
word and take a look at the table properties. Observe the indent is gone.

Run the same test at 547b740f5c753c44594dcacebf69d9433b5a76f8 and open up the result in word and observe
that the indent is as expected.