### PR TITLE
Compress DOCX zip entries with deflate

### DIFF
--- a/docx-core/src/zipper/mod.rs
+++ b/docx-core/src/zipper/mod.rs
@@ -52,7 +52,7 @@ where
     zip.add_directory("docProps/", directory_options)?;
 
     let options = SimpleFileOptions::default()
-        .compression_method(zip::CompressionMethod::Stored)
+        .compression_method(zip::CompressionMethod::Deflated)
         .unix_permissions(0o755);
 
     zip.start_file("[Content_Types].xml", options)?;
@@ -169,7 +169,7 @@ where
     zip.add_directory("docProps/", directory_options)?;
 
     let options = SimpleFileOptions::default()
-        .compression_method(zip::CompressionMethod::Stored)
+        .compression_method(zip::CompressionMethod::Deflated)
         .unix_permissions(0o755);
     let mut xml_buffer = Vec::new();
 


### PR DESCRIPTION
## What changed

- Write DOCX zip entries with `CompressionMethod::Deflated` instead of `Stored`.
- Both call sites in `docx-core/src/zipper/mod.rs` are updated (`zip` and the image-carrying variant).

```diff
 let options = SimpleFileOptions::default()
-    .compression_method(zip::CompressionMethod::Stored)
+    .compression_method(zip::CompressionMethod::Deflated)
     .unix_permissions(0o755);
```

No dependency change: `zip` is already declared with `features = ["deflate"]`.

## Why

DOCX parts are XML, which compresses very well. Writing them uncompressed inflates the output several times over.

Measured on documents produced through `docx-wasm`, repacked with deflate without touching the contents:

| Document | `Stored` (current) | `Deflated` | Ratio |
| --- | ---: | ---: | ---: |
| single paragraph | 28.8 KB | 7.6 KB | **3.8x** |
| field-heavy document | 140.4 KB | 12.1 KB | **11.6x** |
| real-world document (586 paragraphs) | 4,225.2 KB | 203.8 KB | **20.7x** |

Per entry, for example `[Content_Types].xml` goes from 2,077 to 407 bytes (80% smaller).

Word itself writes deflated DOCX, and other implementations do too, so `Stored` is unusual here and there does not appear to be a compatibility reason for it.

## Impact

- Generated DOCX files get substantially smaller (storage, transfer, and download all benefit).
- Compression costs some CPU, but only over the XML parts, which are small to begin with.
- **No reader-side change is needed.** The `zip` crate reads both `Stored` and `Deflated`, so previously generated files still open.

## How I found this

I was building a tool that edits DOCX from an LLM and needs to move the generated file around. A 586-paragraph document came to 5.6 MB as base64, which was impractical, and tracing it led to this line. With deflate it drops to 272 KB.

## Test

- `make test` — 325 unit + 41 integration + 21 reader tests pass, 0 failures.
- `make lint` — clean.
- No snapshot updates needed: the `reader` snapshots and the `docx-wasm` Jest snapshots all compare parsed structures, not raw zip bytes.

Verified on a freshly generated fixture:

```
before:  [Content_Types].xml  2077  Stored  2077   0%
after:   [Content_Types].xml  2077  Defl:N   407  80%
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
