### PR TITLE
Preserve picture rotation while reading DOCX

### DIFF
--- a/docx-core/src/reader/pic.rs
+++ b/docx-core/src/reader/pic.rs
@@ -24,6 +24,19 @@ impl ElementReader for Pic {
                                     pic = pic.id(id)
                                 }
                             }
+                            AXMLElement::Xfrm => {
+                                if let Some(rotation) = read(&attributes, "rot") {
+                                    if let Ok(rotation) = i64::from_str(&rotation) {
+                                        const UNITS_PER_DEGREE: i64 = 60_000;
+                                        const FULL_TURN_UNITS: i64 = 360 * UNITS_PER_DEGREE;
+                                        let normalized = rotation.rem_euclid(FULL_TURN_UNITS);
+                                        let degrees = ((normalized + UNITS_PER_DEGREE / 2)
+                                            / UNITS_PER_DEGREE)
+                                            % 360;
+                                        pic = pic.rotate(degrees as u16);
+                                    }
+                                }
+                            }
                             AXMLElement::Off => {
                                 let mut offset_x: i32 = 0;
                                 let mut offset_y: i32 = 0;
@@ -68,5 +81,28 @@ impl ElementReader for Pic {
                 _ => {}
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reads_picture_rotation_from_transform() {
+        let xml = r#"<pic:pic xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+            <pic:blipFill><a:blip r:embed="rId1"/></pic:blipFill>
+            <pic:spPr>
+                <a:xfrm rot="20933656">
+                    <a:off x="0" y="0"/>
+                    <a:ext cx="4366365" cy="4366365"/>
+                </a:xfrm>
+            </pic:spPr>
+        </pic:pic>"#;
+        let mut reader = EventReader::new(xml.as_bytes());
+
+        let picture = Pic::read(&mut reader, &[]).expect("picture should parse");
+
+        assert_eq!(picture.rot, 349);
     }
 }


### PR DESCRIPTION
## Summary

- parse `a:xfrm rot` while reading DrawingML pictures
- normalize the OOXML angle and round it to the nearest whole degree supported by `Pic.rot`
- add regression coverage for the `20933656` angle used by the office2pdf event-poster fixture

This prevents picture rotation from being reset to zero when a DOCX is read.

## Validation

- red regression test: `left: 0`, `right: 349`
- `RUSTUP_TOOLCHAIN=1.88.0 cargo fmt --all -- --check`
- `RUSTUP_TOOLCHAIN=1.88.0 make test` (361 unit, 41 integration, 21 reader, 1 WASM, and doctests passed)
- `RUSTUP_TOOLCHAIN=1.88.0 make lint`
- `git diff --check`

Related: https://github.com/developer0hye/office2pdf/issues/1366